### PR TITLE
Configure FactoryBot file paths

### DIFF
--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -23,5 +23,9 @@ module ExampleApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+
+    config.factory_bot.definition_file_paths = [
+      File.expand_path("../../factories", __dir__)
+    ]
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path("../../spec/example_app/config/environment", __FILE__)
 
 require "rspec/rails"
 require 'pry'
-require "factories"
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
This commit configures the definition path for factory bot to point to
our factories file. Usually this file is inside the example app, but
because we also use the factories for integration specs we keep it at
the top level.