### PR TITLE
Change movies revenue column limit from 4 to 8

### DIFF
--- a/spec/example_app/db/migrate/20200313180126_change_movie_revenue_limit.rb
+++ b/spec/example_app/db/migrate/20200313180126_change_movie_revenue_limit.rb
@@ -1,0 +1,9 @@
+class ChangeMovieRevenueLimit < ActiveRecord::Migration[6.0]
+  def up
+    change_column :movies, :revenue, :integer, limit: 8
+  end
+
+  def down
+    change_column :movies, :revenue, :integer, limit: 4
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_11_125252) do
+ActiveRecord::Schema.define(version: 2020_03_13_180126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2020_03_11_125252) do
     t.string "overview"
     t.boolean "adult"
     t.string "status"
-    t.integer "revenue"
+    t.bigint "revenue"
     t.integer "runtime"
     t.integer "vote_count"
     t.integer "budget"


### PR DESCRIPTION
When importing movie details the revenue for Avengers: Endgame was
returned as `2797800564`. When attempting to save this an exception was
raised:

```
ActiveModel::RangeError: 2797800564 is out of range for
ActiveModel::Type::Integer with limit 4 bytes
```

The default :limit for an integer column is 4 bytes. [This represents
the range from -2147483648 to +2147483647][1].

This commit update the limit of the column to 8 which will allow for
larger integers.

[1]: https://www.postgresql.org/docs/12/datatype-numeric.html