### PR TITLE
Combine all inputs into a single list.

### DIFF
--- a/lib/yuriita/assembler.rb
+++ b/lib/yuriita/assembler.rb
@@ -8,9 +8,9 @@ module Yuriita
     end
 
     def build(query)
-      expression_filter_clauses(query.expression_inputs) +
+      expression_filter_clauses(query.inputs) +
         keyword_filter_clauses(query) +
-        sorter_clauses(query.sort_inputs)
+        sorter_clauses(query.inputs)
     end
 
     private
@@ -27,7 +27,7 @@ module Yuriita
       keyword_filter_assembler.new(
         keyword_filters: keyword_filters,
         keywords: query.keywords,
-        scope_inputs: query.scope_inputs,
+        scope_inputs: query.inputs,
       ).assemble
     end
 

--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -11,9 +11,7 @@ module Yuriita
       clause("SPACE? .fragment SPACE?") do |fragment|
         Query.new(
           keywords: fragment.keywords,
-          expression_inputs: fragment.expression_inputs,
-          scope_inputs: fragment.scope_inputs,
-          sort_inputs: fragment.sort_inputs,
+          inputs: fragment.inputs,
         )
       end
     end
@@ -22,14 +20,14 @@ module Yuriita
       clause(".keyword") do |keyword|
         Query::Fragment.new(keywords: [keyword])
       end
-      clause(".scope_input") do |scope_input|
-        Query::Fragment.new(scope_inputs: [scope_input])
+      clause(".search_input") do |search_input|
+        Query::Fragment.new(inputs: [search_input])
       end
       clause(".expression_input") do |expression_input|
-        Query::Fragment.new(expression_inputs: [expression_input])
+        Query::Fragment.new(inputs: [expression_input])
       end
       clause(".sort_input") do |sort_input|
-        Query::Fragment.new(sort_inputs: [sort_input])
+        Query::Fragment.new(inputs: [sort_input])
       end
       clause(".fragment SPACE .fragment") do |head, tail|
         head.merge(tail)
@@ -49,7 +47,7 @@ module Yuriita
       end
     end
 
-    production(:scope_input) do
+    production(:search_input) do
       clause("IN COLON .scope") do |scope|
         Query::Input.new(qualifier: "in", term: scope)
       end

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -1,12 +1,10 @@
 module Yuriita
   class Query
-    attr_reader :keywords, :expression_inputs, :scope_inputs, :sort_inputs
+    attr_reader :keywords, :inputs
 
-    def initialize(keywords: [], expression_inputs: [], scope_inputs: [], sort_inputs: [])
+    def initialize(keywords: [], inputs: [])
       @keywords = keywords
-      @expression_inputs = expression_inputs
-      @scope_inputs = scope_inputs
-      @sort_inputs = sort_inputs
+      @inputs = inputs
     end
   end
 end

--- a/lib/yuriita/query/fragment.rb
+++ b/lib/yuriita/query/fragment.rb
@@ -1,21 +1,17 @@
 module Yuriita
   class Query
     class Fragment
-      attr_reader :keywords, :expression_inputs, :scope_inputs, :sort_inputs
+      attr_reader :keywords, :inputs
 
-      def initialize(keywords: [], expression_inputs: [], scope_inputs: [], sort_inputs: [])
+      def initialize(keywords: [], inputs: [])
         @keywords = keywords
-        @expression_inputs = expression_inputs
-        @scope_inputs = scope_inputs
-        @sort_inputs = sort_inputs
+        @inputs = inputs
       end
 
       def merge(other)
         Fragment.new(
           keywords: keywords + other.keywords,
-          expression_inputs: expression_inputs + other.expression_inputs,
-          scope_inputs: scope_inputs + other.scope_inputs,
-          sort_inputs: sort_inputs + other.sort_inputs,
+          inputs: inputs + other.inputs,
         )
       end
     end

--- a/spec/yuriita/assembler_spec.rb
+++ b/spec/yuriita/assembler_spec.rb
@@ -5,8 +5,8 @@ require "yuriita/query/definition"
 RSpec.describe Yuriita::Assembler do
   describe "#build" do
     it "apples the expression_inputs to each filter" do
-      expression_inputs = [ double(:expression_input) ]
-      query = double(:query, expression_inputs: expression_inputs, keywords: [], scope_inputs: [], sort_inputs: [])
+      inputs = [ double(:expression_input) ]
+      query = double(:query, inputs: inputs, keywords: [])
       first_result = double(:result)
       second_result = double(:result)
       first_filter = double(:filter, apply: first_result)
@@ -17,8 +17,8 @@ RSpec.describe Yuriita::Assembler do
       result = described_class.new(definition).build(query)
 
       expect(result).to eq [first_result, second_result]
-      expect(first_filter).to have_received(:apply).with(expression_inputs)
-      expect(second_filter).to have_received(:apply).with(expression_inputs)
+      expect(first_filter).to have_received(:apply).with(inputs)
+      expect(second_filter).to have_received(:apply).with(inputs)
     end
   end
 end

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Yuriita::Parser do
       ))
 
       expect(query.keywords).to eq ["hello"]
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug")
       )
     end
@@ -34,7 +34,7 @@ RSpec.describe Yuriita::Parser do
       ))
 
       expect(query.keywords).to eq ["hello", "world"]
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug")
       )
     end
@@ -53,7 +53,7 @@ RSpec.describe Yuriita::Parser do
 
 
       expect(query.keywords).to eq ["hello", "world"]
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug"),
         an_input_matching("label", "security")
       )
@@ -78,7 +78,7 @@ RSpec.describe Yuriita::Parser do
       ))
 
       expect(query.keywords).to eq ["hello", "world", "search", "term"]
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "red"),
         an_input_matching("label", "blue"),
         an_input_matching("label", "green"),
@@ -88,7 +88,7 @@ RSpec.describe Yuriita::Parser do
     it "parses an expression input" do
       query = parse(tokens([:WORD, "is"], [:COLON], [:WORD, "active"], [:EOS]))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("is", "active"),
       )
     end
@@ -98,7 +98,7 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "label"], [:COLON], [:QUOTE], [:WORD, "bug"], [:QUOTE], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug"),
       )
     end
@@ -109,7 +109,7 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "report"], [:QUOTE], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug report"),
       )
     end
@@ -122,7 +122,7 @@ RSpec.describe Yuriita::Parser do
         [:QUOTE], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug report"),
       )
     end
@@ -134,7 +134,7 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "author"], [:COLON], [:WORD, "eebs"], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug"),
         an_input_matching("label", "security"),
         an_input_matching("author", "eebs"),
@@ -146,7 +146,7 @@ RSpec.describe Yuriita::Parser do
         [:NEGATION], [:WORD, "label"], [:COLON], [:WORD, "bug"], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug").negated,
       )
     end
@@ -157,7 +157,7 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "label"], [:COLON], [:WORD, "security"], [:EOS],
       ))
 
-      expect(query.expression_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug").negated,
         an_input_matching("label", "security")
       )
@@ -167,7 +167,7 @@ RSpec.describe Yuriita::Parser do
       query = parse(tokens(
         [:SORT], [:COLON], [:WORD, "title"], [:EOS],
       ))
-      expect(query.sort_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("sort", "title")
       )
     end
@@ -177,7 +177,7 @@ RSpec.describe Yuriita::Parser do
         [:IN], [:COLON], [:WORD, "title"], [:EOS],
       ))
 
-      expect(query.scope_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("in", "title")
       )
     end
@@ -195,7 +195,7 @@ RSpec.describe Yuriita::Parser do
       ))
 
       expect(query.keywords).to eq ["awesome", "ideas"]
-      expect(query.scope_inputs).to contain_exactly(
+      expect(query.inputs).to contain_exactly(
         an_input_matching("in", "title")
       )
     end

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -10,21 +10,12 @@ RSpec.describe Yuriita::Query do
     end
   end
 
-  describe "#expression_inputs" do
-    it "returns the initialized expression_inputs" do
-      expression_inputs = double(:expression_inputs)
-      query = described_class.new(expression_inputs: expression_inputs)
+  describe "#inputs" do
+    it "returns the initialized" do
+      inputs = double(:inputs)
+      query = described_class.new(inputs: inputs)
 
-      expect(query.expression_inputs).to eq expression_inputs
-    end
-  end
-
-  describe "#sort_inputs" do
-    it "returns the initialized sort_inputs" do
-      sort_inputs = double(:sort_inputs)
-      query = described_class.new(sort_inputs: sort_inputs)
-
-      expect(query.sort_inputs).to eq sort_inputs
+      expect(query.inputs).to eq inputs
     end
   end
 end


### PR DESCRIPTION
Because we handle all matching at the filter level, we don't need to
preemptively split the "types" of inputs into different lists.

This consolidates all the inputs into a single list in the query. When
filters are run, all inputs are passed to it and the filter's matchers
select the appropriate inputs.