### PR TITLE
Allow parsing of an empty string

### DIFF
--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -14,6 +14,7 @@ module Yuriita
           inputs: fragment.inputs,
         )
       end
+      clause("SPACE?") { |_| Query.new }
     end
 
     production(:fragment) do

--- a/spec/integration/empty_spec.rb
+++ b/spec/integration/empty_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "an empty input string" do
+  it "results in the original relation" do
+    create_list(:post, 3)
+
+    result = Yuriita.sift(
+      Post.all,
+      "",
+      definition: Yuriita::Query::Definition.new,
+    )
+
+    expect(result.relation).to match_array(Post.all)
+  end
+end

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -3,6 +3,13 @@ require "yuriita/parser"
 
 RSpec.describe Yuriita::Parser do
   describe '#parse' do
+    it "parses an empty string" do
+      query = parse(tokens([:EOS]))
+
+      expect(query.keywords).to eq []
+      expect(query.inputs).to eq []
+    end
+
     it "parses keywords" do
       query = parse(tokens([:WORD, "hello"], [:EOS]))
 


### PR DESCRIPTION
An empty string should result in returning the existing relation.