### PR TITLE
Use Zeitwerk for code loading

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       rltk
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/

--- a/lib/yuriita.rb
+++ b/lib/yuriita.rb
@@ -1,21 +1,8 @@
-require "yuriita/version"
-require "yuriita/errors"
-
-require "yuriita/runner"
-require "yuriita/query_builder"
-
-require "yuriita/query"
-require "yuriita/query/definition"
-
-require "yuriita/or_combination"
-require "yuriita/and_combination"
-
-require "yuriita/expression_filter"
-require "yuriita/keyword_filter"
-require "yuriita/sorter"
-
-require "yuriita/clauses/where"
-require "yuriita/clauses/order"
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.ignore("#{__dir__}/yuri-ita.rb")
+loader.collapse("#{__dir__}/yuriita/errors")
+loader.setup
 
 module Yuriita
   def self.filter(relation, input, definition)
@@ -30,3 +17,5 @@ module Yuriita
     QueryBuilder.build(input)
   end
 end
+
+loader.eager_load

--- a/lib/yuriita/assembler.rb
+++ b/lib/yuriita/assembler.rb
@@ -1,5 +1,3 @@
-require "yuriita/keyword_filter_assembler"
-
 module Yuriita
   class Assembler
     def initialize(definition, keyword_filter_assembler: KeywordFilterAssembler)

--- a/lib/yuriita/errors/error.rb
+++ b/lib/yuriita/errors/error.rb
@@ -1,7 +1,4 @@
 module Yuriita
   class Error < StandardError
   end
-
-  class ParseError < Error
-  end
 end

--- a/lib/yuriita/errors/parse_error.rb
+++ b/lib/yuriita/errors/parse_error.rb
@@ -1,0 +1,4 @@
+module Yuriita
+  class ParseError < Yuriita::Error
+  end
+end

--- a/lib/yuriita/expression_filter.rb
+++ b/lib/yuriita/expression_filter.rb
@@ -1,5 +1,3 @@
-require "yuriita/clauses/merge"
-
 module Yuriita
   class ExpressionFilter
     def initialize(matcher:, combination:, &block)

--- a/lib/yuriita/keyword_filter.rb
+++ b/lib/yuriita/keyword_filter.rb
@@ -1,5 +1,3 @@
-require "yuriita/clauses/merge"
-
 module Yuriita
   class KeywordFilter
     def initialize(matcher:, combination:, &block)

--- a/lib/yuriita/keyword_filter_assembler.rb
+++ b/lib/yuriita/keyword_filter_assembler.rb
@@ -1,6 +1,3 @@
-require "yuriita/or_combination"
-require "yuriita/clauses/merge"
-
 module Yuriita
   class KeywordFilterAssembler
     def initialize(keyword_filters:, keywords:, scope_inputs:, combination: OrCombination)

--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -1,7 +1,4 @@
 require "rltk/parser"
-require "yuriita/query"
-require "yuriita/query/fragment"
-require "yuriita/query/input"
 
 module Yuriita
   class Parser < RLTK::Parser

--- a/lib/yuriita/runner.rb
+++ b/lib/yuriita/runner.rb
@@ -1,9 +1,3 @@
-require "yuriita/parser"
-require "yuriita/lexer"
-require "yuriita/result"
-require "yuriita/executor"
-require "yuriita/assembler"
-
 module Yuriita
   class Runner
     def initialize(relation:, definition:, **options)

--- a/spec/integration/combined_search_filter_sort_spec.rb
+++ b/spec/integration/combined_search_filter_sort_spec.rb
@@ -1,7 +1,4 @@
 require "rails_helper"
-require "yuriita/or_combination"
-require "yuriita/and_combination"
-require "yuriita/matchers/expression"
 
 RSpec.describe "combining expressions, search, and sort" do
   it "returns keyword results, expression results, and sorted results" do

--- a/spec/integration/filtering/by_expression_spec.rb
+++ b/spec/integration/filtering/by_expression_spec.rb
@@ -1,7 +1,4 @@
 require "rails_helper"
-require "yuriita/or_combination"
-require "yuriita/and_combination"
-require "yuriita/matchers/expression"
 
 RSpec.describe "filtering by expression" do
   it "returns results matching an expression" do

--- a/spec/support/tokens.rb
+++ b/spec/support/tokens.rb
@@ -1,5 +1,3 @@
-require "rltk"
-
 module Tokens
   def tokens(*tokens)
     tokens.map.with_index do |token, i|

--- a/spec/yuriita/assembler_spec.rb
+++ b/spec/yuriita/assembler_spec.rb
@@ -1,7 +1,3 @@
-require "spec_helper"
-require "yuriita/assembler"
-require "yuriita/query/definition"
-
 RSpec.describe Yuriita::Assembler do
   describe "#build" do
     it "apples the expression_inputs to each filter" do

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require 'yuriita/lexer'
-
 RSpec.describe Yuriita::Lexer do
   describe ".lex" do
     it "recognizes colon separated words" do

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "yuriita/parser"
-
 RSpec.describe Yuriita::Parser do
   describe '#parse' do
     it "parses an empty string" do

--- a/spec/yuriita/query/input_spec.rb
+++ b/spec/yuriita/query/input_spec.rb
@@ -1,5 +1,3 @@
-require "yuriita/query/input"
-
 RSpec.describe Yuriita::Query::Input do
   describe "#qualifier" do
     it "returns the provided qualifier" do

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe Yuriita::Query do
   describe "#keywords" do
     it "returns the initialized keywords" do

--- a/yuri-ita.gemspec
+++ b/yuri-ita.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "activerecord", ">= 4.2"
   spec.add_dependency "activemodel", ">= 4.2"
+  spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
[Zeitwerk] is the new code loader in Rails 6 and provides a reasonable
approach to file structure and constant loading. It removes the need to
add `require` statements and ensure the ordering of those statements is
correct.

This commit adds the Zeitwerk code loading and configures it to eager
load the entire gem.

If someone adds `gem "yuri-ita"` to their Gemfile Bundler will load
`yuri-ita.rb`. This file is set up to `require "yuriita.rb"` so we don't
have to deal with inflections. We ignore the `yuri-ita.rb` file and rely
on `yuriita.rb` to be the main entry point.

I also removed a number of places where we were calling

```
require "spec_helper"
```

This is done by `.rspec` and is unnecessary.

[Zeitwerk]: https://github.com/fxn/zeitwerk