### PR TITLE
Allow hyphens in words

### DIFF
--- a/lib/yuriita/lexer.rb
+++ b/lib/yuriita/lexer.rb
@@ -6,7 +6,7 @@ module Yuriita
     rule(/:/) { :COLON }
     rule(/in/) { :IN }
     rule(/sort/) { :SORT }
-    rule(/[a-zA-Z_]+/) { |t| [:WORD, t] }
+    rule(/[a-zA-Z_-]+/) { |t| [:WORD, t] }
     rule(/"/) { :QUOTE }
   end
 end

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe Yuriita::Lexer do
       )
     end
 
+    it "recognizes words with hyphens" do
+      expect("sort:created-desc").to produce_tokens(
+        [
+          "SORT",
+          "COLON",
+          "WORD(created-desc)",
+          "EOS",
+        ]
+      )
+    end
+
     it "recognizes quoted words" do
       expect("\"quoted words\"").to produce_tokens(
         [


### PR DESCRIPTION
We may wish to use hyphens in words such as in the input
`sort:created-desc`or `created-by:eebs`.

This commit updates the lexer to allow hyphens in words.

When we re-introduce negation we should be careful to test edgecases
that involve hyphens:

```
-created-by:eebs
```