### PR TITLE
Allow quoted keyword phrases

### DIFF
--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -34,6 +34,7 @@ module Yuriita
 
     production(:keyword) do
       clause(:WORD) { |word| word }
+      clause("QUOTE SPACE? .phrase SPACE? QUOTE") { |phrase| phrase.join(" ") }
     end
 
     production(:expression_input) do

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe Yuriita::Parser do
       )
     end
 
+    it "parses quoted keyword phrases" do
+      query = parse(tokens(
+        [:QUOTE],
+        [:WORD, "hello"], [:SPACE], [:WORD, "world"],
+        [:QUOTE],
+        [:EOS],
+      ))
+
+      expect(query.keywords).to eq ["hello world"]
+    end
+
     it "parses keywords with an expression_input between them" do
       query = parse(tokens(
         [:WORD, "hello"],


### PR DESCRIPTION
Someone may wish to search for a multi-word keyword phrase such as
"apple pie". They specifically want to find the phrase `apple pie`
rather than items containing both the words `apple` and `pie`.

```
"apple pie" in:title is:published
```

This commit updates the parser to allow keywords to also consist of
quoted phrases.