### PR TITLE
Add methods for filtering and searching models

### DIFF
--- a/spec/example_app/app/models/movie.rb
+++ b/spec/example_app/app/models/movie.rb
@@ -1,2 +1,19 @@
 class Movie < ApplicationRecord
+
+  module Status
+    RUMORED = "Rumored".freeze
+    POST_PRODUCTION = "Post Production".freeze
+    RELEASED = "Released".freeze
+    CANCELLED = "Cancelled".freeze
+  end
+
+  scope :rumored, -> { where(status: Status::RUMORED) }
+  scope :post_production, -> { where(status: Status::POST_PRODUCTION) }
+  scope :released, -> { where(status: Status::RELEASED) }
+  scope :cancelled, -> { where(status: Status::CANCELLED) }
+
+  def self.search(field, term)
+    sanitized_value = sanitize_sql_like(term)
+    where("#{field} ILIKE :term", term: "%#{sanitized_value}%")
+  end
 end

--- a/spec/example_app/app/models/post.rb
+++ b/spec/example_app/app/models/post.rb
@@ -3,4 +3,12 @@ class Post < ApplicationRecord
   has_many :categories, through: :post_categories
 
   validates_presence_of :title, :body
+
+  scope :published, -> { where(published: true) }
+  scope :draft, -> { where(published: false) }
+
+  def self.search(field, term)
+    sanitized_value = sanitize_sql_like(term)
+    where("#{field} ILIKE :term", term: "%#{sanitized_value}%")
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,14 @@ FactoryBot.define do
   factory :post do
     title { "A title" }
     body { "A body" }
+
+    trait :published do
+      published { true }
+    end
+
+    trait :draft do
+      published { false }
+    end
   end
 
   factory :category do
@@ -25,5 +33,21 @@ FactoryBot.define do
     vote_average { 8.4 }
     popularity { 34.117 }
     release_date { "1999-10-12" }
+
+    trait :rumored do
+      status { Movie::Status::RUMORED }
+    end
+
+    trait :post_production do
+      status { Movie::Status::POST_PRODUCTION }
+    end
+
+    trait :released do
+      status { Movie::Status::RELEASED }
+    end
+
+    trait :cancelled do
+      status { Movie::Status::CANCELLED }
+    end
   end
 end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -1,4 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe Movie, type: :model do
+  describe ".rumored" do
+    it "returns movies with the rumored status" do
+      rumored = create(:movie, :rumored)
+      post_production = create(:movie, :post_production)
+
+      results = Movie.rumored
+
+      expect(results).to contain_exactly(rumored)
+    end
+  end
+
+  describe ".post_production" do
+    it "returns movies with the rumored status" do
+      post_production = create(:movie, :post_production)
+      released = create(:movie, :released)
+
+      results = Movie.post_production
+
+      expect(results).to contain_exactly(post_production)
+    end
+  end
+
+  describe ".released" do
+    it "returns movies with the rumored status" do
+      released = create(:movie, :released)
+      cancelled = create(:movie, :cancelled)
+
+      results = Movie.released
+
+      expect(results).to contain_exactly(released)
+    end
+  end
+
+  describe ".cancelled" do
+    it "returns movies with the rumored status" do
+      cancelled = create(:movie, :cancelled)
+      rumored = create(:movie, :rumored)
+
+      results = Movie.cancelled
+
+      expect(results).to contain_exactly(cancelled)
+    end
+  end
+
+  describe ".search" do
+    it "searches the given field for the term" do
+      duck_movie = create(:movie, title: "Mighty Ducks")
+      not_ducks_movie = create(:movie, title: "Cats", tagline: "Cats not ducks")
+
+      results = Movie.search(:title, "ducks")
+
+      expect(results).to contain_exactly(duck_movie)
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Post, type: :model do
+  describe ".published" do
+    it "returns published posts" do
+      published = create(:post, :published)
+      draft = create(:post, :draft)
+
+      results = Post.published
+
+      expect(results).to contain_exactly(published)
+    end
+  end
+
+  describe ".draft" do
+    it "returns draft posts" do
+      published = create(:post, :published)
+      draft = create(:post, :draft)
+
+      results = Post.draft
+
+      expect(results).to contain_exactly(draft)
+    end
+  end
+end


### PR DESCRIPTION
For the demo application we'd like to be able to search and filter
Movies.

This commit adds scopes and a `.search` method to the Movie and Post
model.