### PR TITLE
Use formatter to generate view option params

### DIFF
--- a/lib/yuriita/exclusive_collection.rb
+++ b/lib/yuriita/exclusive_collection.rb
@@ -1,9 +1,9 @@
 module Yuriita
   class ExclusiveCollection
-    def initialize(definition:, query:, param_key: nil)
+    def initialize(definition:, query:, formatter: nil)
       @definition = definition
       @query = query
-      @param_key = param_key
+      @formatter = formatter
     end
 
     def apply(relation)
@@ -20,7 +20,7 @@ module Yuriita
 
     private
 
-    attr_reader :definition, :query, :param_key
+    attr_reader :definition, :query, :formatter
 
     def view_option(option)
       ViewOption.new(
@@ -38,16 +38,18 @@ module Yuriita
     end
 
     def params(option)
-      format inputs_for(option)
+      formatter.format build_query(option)
     end
 
-    def inputs_for(option)
+    def build_query(option)
       if selected?(option)
-        inputs
+        query.dup
       else
-        inputs.reject do |input|
+        option_query = query.dup
+        option_query.delete_if do |input|
           options.any? { |option| option.match?([input]) }
-        end + [option.build_input]
+        end
+        option_query << option.build_input
       end
     end
 
@@ -90,15 +92,6 @@ module Yuriita
 
     def default_option
       definition.default
-    end
-
-    def format(inputs)
-      value = inputs.map(&:to_s).join(" ") + " " + joined_keywords
-      { param_key => value.strip }
-    end
-
-    def joined_keywords
-      query.keywords.join(" ")
     end
   end
 end

--- a/lib/yuriita/exclusive_definition.rb
+++ b/lib/yuriita/exclusive_definition.rb
@@ -18,7 +18,7 @@ module Yuriita
       ExclusiveCollection.new(
         definition: self,
         query: query,
-        param_key: param_key
+        formatter: Yuriita::QueryFormatter.new(param_key: param_key),
       ).view_options
     end
   end

--- a/lib/yuriita/multiple_collection.rb
+++ b/lib/yuriita/multiple_collection.rb
@@ -1,9 +1,9 @@
 module Yuriita
   class MultipleCollection
-    def initialize(definition:, query:, param_key: nil)
+    def initialize(definition:, query:, formatter: nil)
       @definition = definition
       @query = query
-      @param_key = param_key
+      @formatter = formatter
     end
 
     def apply(relation)
@@ -27,7 +27,7 @@ module Yuriita
 
     private
 
-    attr_reader :definition, :query, :param_key
+    attr_reader :definition, :query, :formatter
 
     def view_option(option)
       ViewOption.new(
@@ -42,14 +42,18 @@ module Yuriita
     end
 
     def params(option)
-      format inputs_for(option)
+      formatter.format build_query(option)
     end
 
-    def inputs_for(option)
+    def build_query(option)
       if selected?(option)
-        inputs.reject { |input| option.match?([input]) }
+        option_query = query.dup
+        option_query.delete_if do |input|
+          option.match?([input])
+        end
       else
-        inputs + [option.build_input]
+        option_query = query.dup
+        option_query << option.build_input
       end
     end
 
@@ -67,15 +71,6 @@ module Yuriita
 
     def options
       definition.options
-    end
-
-    def format(inputs)
-      value = inputs.map(&:to_s).join(" ") + " " + joined_keywords
-      { param_key => value.strip }
-    end
-
-    def joined_keywords
-      query.keywords.join(" ")
     end
   end
 end

--- a/lib/yuriita/multiple_definition.rb
+++ b/lib/yuriita/multiple_definition.rb
@@ -18,7 +18,7 @@ module Yuriita
       MultipleCollection.new(
         definition: self,
         query: query,
-        param_key: param_key
+        formatter: Yuriita::QueryFormatter.new(param_key: param_key),
       ).view_options
     end
   end

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -1,10 +1,52 @@
 module Yuriita
   class Query
+    include Enumerable
+
     attr_reader :keywords, :inputs
 
     def initialize(keywords: [], inputs: [])
       @keywords = keywords
       @inputs = inputs
+    end
+
+    def each(&block)
+      block or return enum_for(__method__) { size }
+      inputs.each(&block)
+      self
+    end
+
+    def each_element(&block)
+      block or return enum_for(__method__) { size + keywords.size }
+      elements = inputs + keywords
+      elements.each(&block)
+      self
+    end
+
+    def add_input(input)
+      inputs << input
+      self
+    end
+    alias << add_input
+
+    def delete_if
+      block_given? or return enum_for(__method__) { size }
+      select { |input| yield input }.each { |input| inputs.delete(input) }
+      self
+    end
+
+    def size
+      inputs.size
+    end
+    alias length size
+
+    def initialize_dup(original)
+      super
+      @inputs = original.instance_variable_get(:@inputs).dup
+    end
+
+    def initialize_clone(original)
+      super
+      @inputs = original.instance_variable_get(:@inputs).clone
     end
   end
 end

--- a/lib/yuriita/query_formatter.rb
+++ b/lib/yuriita/query_formatter.rb
@@ -1,0 +1,18 @@
+module Yuriita
+  class QueryFormatter
+    SPACE = " ".freeze
+
+    def initialize(param_key:)
+      @param_key = param_key
+    end
+
+    def format(query)
+      value = query.each_element.map(&:to_s).join(SPACE)
+      { param_key => value }
+    end
+
+    private
+
+    attr_reader :param_key
+  end
+end

--- a/lib/yuriita/search_collection.rb
+++ b/lib/yuriita/search_collection.rb
@@ -31,15 +31,15 @@ module Yuriita
     end
 
     def explicit_options
-      options.select { |option| option.match?(inputs) }
+      options.select do |option|
+        query.any? do |input|
+          option.match?([input])
+        end
+      end
     end
 
     def options
       scope.options
-    end
-
-    def inputs
-      query.inputs
     end
 
     def keywords

--- a/lib/yuriita/single_collection.rb
+++ b/lib/yuriita/single_collection.rb
@@ -1,9 +1,9 @@
 module Yuriita
   class SingleCollection
-    def initialize(definition:, query:, param_key: nil)
+    def initialize(definition:, query:, formatter: nil)
       @definition = definition
       @query = query
-      @param_key = param_key
+      @formatter = formatter
     end
 
     def apply(relation)
@@ -24,7 +24,7 @@ module Yuriita
 
     private
 
-    attr_reader :definition, :query, :param_key
+    attr_reader :definition, :query, :formatter
 
     def view_option(option)
       ViewOption.new(
@@ -43,18 +43,21 @@ module Yuriita
     end
 
     def params(option)
-      format inputs_for(option)
+      formatter.format build_query(option)
     end
 
-    def inputs_for(option)
+    def build_query(option)
       if selected?(option)
-        inputs.reject do |input|
+        option_query = query.dup
+        option_query.delete_if do |input|
           options.any? { |option| option.match?([input]) }
         end
       else
-        inputs.reject do |input|
+        option_query = query.dup
+        option_query.delete_if do |input|
           options.any? { |option| option.match?([input]) }
-        end + [option.build_input]
+        end
+        option_query << option.build_input
       end
     end
 
@@ -85,15 +88,6 @@ module Yuriita
 
     def options
       definition.options
-    end
-
-    def format(inputs)
-      value = inputs.map(&:to_s).join(" ") + " " + joined_keywords
-      { param_key => value.strip }
-    end
-
-    def joined_keywords
-      query.keywords.join(" ")
     end
   end
 end

--- a/lib/yuriita/single_definition.rb
+++ b/lib/yuriita/single_definition.rb
@@ -17,7 +17,7 @@ module Yuriita
       SingleCollection.new(
         definition: self,
         query: query,
-        param_key: param_key
+        formatter: Yuriita::QueryFormatter.new(param_key: param_key),
       ).view_options
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,4 +50,13 @@ FactoryBot.define do
       status { Movie::Status::CANCELLED }
     end
   end
+
+  factory :input, class: "Yuriita::Query::Input" do
+    skip_create
+
+    qualifier { "is" }
+    term { "published" }
+
+    initialize_with { new(attributes) }
+  end
 end

--- a/spec/yuriita/query_formatter_spec.rb
+++ b/spec/yuriita/query_formatter_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Yuriita::QueryFormatter do
+  describe "#format" do
+    it "returns a an input string keyed by the param_key" do
+      published = build(:input, qualifier: "is", term: "published")
+      title = build(:input, qualifier: "in", term: "title")
+      query = Yuriita::Query.new(inputs: [published, title], keywords: ["cats"])
+
+      formatted = described_class.new(param_key: :q).format(query)
+
+      expect(formatted).to eq({ q: "is:published in:title cats" })
+    end
+
+    it "returns an empty string when the query is empty" do
+      query = Yuriita::Query.new
+
+      formatted = described_class.new(param_key: :q).format(query)
+
+      expect(formatted).to eq({ q: "" })
+    end
+  end
+end

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -16,4 +16,115 @@ RSpec.describe Yuriita::Query do
       expect(query.inputs).to eq inputs
     end
   end
+
+  describe "#dup" do
+    it "duplicates the inputs" do
+      input = Yuriita::Query::Input.new(qualifier: "is", term: "original")
+      new_input = Yuriita::Query::Input.new(qualifier: "is", term: "new")
+      original = described_class.new(inputs: [input])
+
+      duplicate = original.dup
+      duplicate << new_input
+
+      expect(duplicate.inputs).to include(input)
+      expect(original.inputs).not_to include(new_input)
+    end
+  end
+
+  describe "#clone" do
+    it "duplicates the inputs" do
+      input = Yuriita::Query::Input.new(qualifier: "is", term: "original")
+      new_input = Yuriita::Query::Input.new(qualifier: "is", term: "new")
+      original = described_class.new(inputs: [input])
+
+      duplicate = original.clone
+      duplicate << new_input
+
+      expect(duplicate.inputs).to include(input)
+      expect(original.inputs).not_to include(new_input)
+    end
+  end
+
+  describe "#each" do
+    it "yields the inputs" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+      query = described_class.new(inputs: [published, draft])
+
+      expect do |b|
+        query.each(&b)
+      end.to yield_successive_args(published, draft)
+    end
+  end
+
+  describe "#each_element" do
+    it "yields inputs and keywords" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+      query = described_class.new(inputs: [published, draft], keywords: ["cat"])
+
+      expect do |b|
+        query.each_element(&b)
+      end.to yield_successive_args(published, draft, "cat")
+    end
+  end
+
+  describe "#add_input" do
+    it "adds an input to the query" do
+      published = build(:input, qualifier: "is", term: "published")
+      query = described_class.new(inputs: [])
+
+      query.add_input(published)
+
+      expect(query).to include(published)
+    end
+  end
+
+  describe "#include?" do
+    it "is true if the query contains the input" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+
+      query = described_class.new(inputs: [published, draft])
+
+      expect(query).to include(published)
+    end
+
+    it "is false if the query does not contain the input" do
+      published = build(:input, qualifier: "is", term: "published")
+      query = described_class.new(inputs: [])
+
+      expect(query).not_to include(published)
+    end
+  end
+
+  describe "#delete_if" do
+    it "removes inputs matching the block" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+      query = described_class.new(inputs: [published, draft])
+
+      query.delete_if { |input| input == published }
+
+      expect(query).not_to include(published)
+      expect(query).to include(draft)
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of inputs" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+
+      query = described_class.new(inputs: [published, draft])
+
+      expect(query.size).to eq 2
+    end
+
+    it "returns zero when there are no inputs" do
+      query = described_class.new
+
+      expect(query.size).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
### Add Enumerable to Query

We would like to be able to iterate over the inputs in a query so we can
format each in turn. We would also like to be able to add inputs or
remove inputs matching a certain condition.

This commit add the Enumerable module to Query. It adds methods to add
and delete inputs, as well a `each_element` which will yield all the
inputs and then all the keywords. In the future when we figure out how
to preserve the ordering of inputs and keywords `each_element` should
yield items in their original order.

### Use formatter in collections to output new query

Each collection generates a list of options for display. Each option
needs to have a query string that will be used to apply (or unapply)
that option.

The formatter is responsible for taking a query and turning it into a
params hash. The hash contains a single element: the `param_key` whose
value is the new input string.

This commit updates the collections to accept a formatter which it uses
to build the new params.

There's one oddity about this that I hope to address in the near future.
Each collection is used for two purposes. The first is for running the
actual query. This is done via the `apply` method. The second is
generating the view options. This is done via the `view_options` method.

Only the view options requires the formatter. When we build a collection
to apply the query, we don't know the param key, and thus we cannot
build a formatter. So we can't pass a formatter to the collection in the
definition's `apply` method. Because of this, each collection defaults
the `formatter` to `nil`.

This highlights the idea that we really want two separate objects here,
one to handle applying a definition's filters, and another object for
generating view options from a definition. This can only happen once we
have a common interface for both objects, which we don't have at
the moment. Future efforts will work toward this goal.