### PR TITLE
Simplify movie client

### DIFF
--- a/spec/example_app/app/models/movie_client.rb
+++ b/spec/example_app/app/models/movie_client.rb
@@ -5,7 +5,7 @@ class MovieClient
 
   def top_rated
     data.map do |movie_data|
-      Movie.new(
+      {
         tmdb_id: movie_data.id,
         title: movie_data.title,
         original_title: movie_data.original_title,
@@ -22,7 +22,7 @@ class MovieClient
         release_date: movie_data.release_date,
         created_at: Time.now,
         updated_at: Time.now,
-      )
+      }
     end
   end
 

--- a/spec/example_app/app/models/movie_sync.rb
+++ b/spec/example_app/app/models/movie_sync.rb
@@ -20,10 +20,7 @@ class MovieSync
   end
 
   def movie_data
-    movies = client.top_rated
-    movies.map do |movie|
-      movie.attributes.slice(*insert_attributes)
-    end
+    client.top_rated
   end
 
   def insert_attributes

--- a/spec/models/movie_sync_spec.rb
+++ b/spec/models/movie_sync_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe MovieSync do
   describe "#run" do
     it "fetches the top 100 movies from TMDB and inserts them into the DB" do
-      fight_club = build(
+      fight_club = attributes_for(
         :movie,
         title: "Fight Club",
         created_at: Time.now,
         updated_at: Time.now,
       )
-      the_prestige = build(
+      the_prestige = attributes_for(
         :movie,
         title: "The Prestige",
         created_at: Time.now,


### PR DESCRIPTION
Previously, the movie client retrieved data, built movie objects
from that data, and passed the unpersisted movie objects to the movie
sync model. The movie sync model then mapped those movie objects to
attribute hashes before upserting them into the db.

This skips the unpersisted movie model step. Instead, the movie client
keeps the movie data as an array of hashes and passes that to the movie
sync model. The movie sync model can then upsert the hashes directly,
instead of first having to map object to attribute hashes.