### PR TITLE
Remove expression matcher

### DIFF
--- a/lib/yuriita/exclusive_collection.rb
+++ b/lib/yuriita/exclusive_collection.rb
@@ -43,13 +43,17 @@ module Yuriita
 
     def build_query(option)
       if selected?(option)
-        query.dup
+        option_query = query.dup
+        matching_inputs.each do |input|
+          option_query.delete(input)
+        end
+        option_query
       else
         option_query = query.dup
-        option_query.delete_if do |input|
-          options.any? { |option| option.match?([input]) }
+        matching_inputs.each do |input|
+          option_query.delete(input)
         end
-        option_query << option.build_input
+        option_query << option.input
       end
     end
 
@@ -73,17 +77,13 @@ module Yuriita
     end
 
     def option_for(input)
-      options.detect { |option| option.match?([input]) }
+      options.detect { |option| option.input == input }
     end
 
     def matching_inputs
-      inputs.select do |input|
-        options.any? { |option| option.match?([input]) }
+      query.select do |input|
+        options.any? { |option| option.input == input }
       end
-    end
-
-    def inputs
-      query.inputs
     end
 
     def options

--- a/lib/yuriita/exclusive_collection.rb
+++ b/lib/yuriita/exclusive_collection.rb
@@ -62,10 +62,10 @@ module Yuriita
     end
 
     def active_option
-      selected_option || default_option
+      chosen_option || default_option
     end
 
-    def selected_option
+    def chosen_option
       input = last_matching_input
       if input.present?
         option_for(input)

--- a/lib/yuriita/expression_filter.rb
+++ b/lib/yuriita/expression_filter.rb
@@ -1,30 +1,18 @@
 module Yuriita
   class ExpressionFilter
-    def initialize(matcher:, &block)
-      @matcher = matcher
-      @block = block
-    end
+    attr_reader :input
 
-    def matches?(inputs)
-      inputs.any? do |input|
-        matches_input?(input)
-      end
+    def initialize(input:, &block)
+      @input = input
+      @block = block
     end
 
     def apply(relation)
       block.call(relation)
     end
 
-    def build_input
-      matcher.build_input
-    end
-
     private
 
-    attr_reader :matcher, :block
-
-    def matches_input?(input)
-      matcher.match?(input)
-    end
+    attr_reader :block
   end
 end

--- a/lib/yuriita/multiple_collection.rb
+++ b/lib/yuriita/multiple_collection.rb
@@ -38,7 +38,7 @@ module Yuriita
     end
 
     def selected?(option)
-      selected_options.include?(option)
+      active_options.include?(option)
     end
 
     def params(option)
@@ -56,10 +56,10 @@ module Yuriita
     end
 
     def active_filters
-      selected_options.map(&:filter)
+      active_options.map(&:filter)
     end
 
-    def selected_options
+    def active_options
       options.select do |option|
         query.include?(option.input)
       end

--- a/lib/yuriita/multiple_collection.rb
+++ b/lib/yuriita/multiple_collection.rb
@@ -48,12 +48,10 @@ module Yuriita
     def build_query(option)
       if selected?(option)
         option_query = query.dup
-        option_query.delete_if do |input|
-          option.match?([input])
-        end
+        option_query.delete(option.input)
       else
         option_query = query.dup
-        option_query << option.build_input
+        option_query << option.input
       end
     end
 
@@ -62,11 +60,9 @@ module Yuriita
     end
 
     def selected_options
-      options.select { |option| option.match?(inputs) }
-    end
-
-    def inputs
-      query.inputs
+      options.select do |option|
+        query.include?(option.input)
+      end
     end
 
     def options

--- a/lib/yuriita/option.rb
+++ b/lib/yuriita/option.rb
@@ -7,12 +7,8 @@ module Yuriita
       @filter = filter
     end
 
-    def match?(inputs)
-      filter.matches?(inputs)
-    end
-
-    def build_input
-      filter.build_input
+    def input
+      filter.input
     end
   end
 end

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -28,6 +28,11 @@ module Yuriita
     end
     alias << add_input
 
+    def delete(input)
+      inputs.delete(input)
+      self
+    end
+
     def delete_if
       block_given? or return enum_for(__method__) { size }
       select { |input| yield input }.each { |input| inputs.delete(input) }

--- a/lib/yuriita/query/input.rb
+++ b/lib/yuriita/query/input.rb
@@ -8,6 +8,13 @@ module Yuriita
         @term = term
       end
 
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.qualifier == qualifier &&
+          other.term == term
+      end
+      alias_method :eql?, :==
+
       def to_s
         "#{qualifier}:#{term}"
       end

--- a/lib/yuriita/search_collection.rb
+++ b/lib/yuriita/search_collection.rb
@@ -32,9 +32,7 @@ module Yuriita
 
     def explicit_options
       options.select do |option|
-        query.any? do |input|
-          option.match?([input])
-        end
+        query.include?(option.input)
       end
     end
 

--- a/lib/yuriita/search_filter.rb
+++ b/lib/yuriita/search_filter.rb
@@ -1,15 +1,11 @@
 module Yuriita
   class SearchFilter
-    def initialize(matcher:, combination:, &block)
-      @matcher = matcher
+    attr_reader :input
+
+    def initialize(input:, combination:, &block)
+      @input = input
       @combination = combination
       @block = block
-    end
-
-    def matches?(inputs)
-      inputs.any? do |input|
-        matches_input?(input)
-      end
     end
 
     def apply(relation, keywords)
@@ -23,16 +19,8 @@ module Yuriita
       ).combine
     end
 
-    def build_input
-      matcher.build_input
-    end
-
     private
 
-    attr_reader :matcher, :combination, :block
-
-    def matches_input?(input)
-      matcher.match?(input)
-    end
+    attr_reader :combination, :block
   end
 end

--- a/lib/yuriita/single_collection.rb
+++ b/lib/yuriita/single_collection.rb
@@ -49,15 +49,16 @@ module Yuriita
     def build_query(option)
       if selected?(option)
         option_query = query.dup
-        option_query.delete_if do |input|
-          options.any? { |option| option.match?([input]) }
+        matching_inputs.each do |input|
+          option_query.delete(input)
         end
+        option_query
       else
         option_query = query.dup
-        option_query.delete_if do |input|
-          options.any? { |option| option.match?([input]) }
+        matching_inputs.each do |input|
+          option_query.delete(input)
         end
-        option_query << option.build_input
+        option_query << option.input
       end
     end
 
@@ -73,17 +74,13 @@ module Yuriita
     end
 
     def option_for(input)
-      options.detect { |option| option.match?([input]) }
+      options.detect { |option| option.input == input }
     end
 
     def matching_inputs
-      inputs.select do |input|
-        options.any? { |option| option.match?([input]) }
+      query.select do |input|
+        options.any? { |option| option.input == input }
       end
-    end
-
-    def inputs
-      query.inputs
     end
 
     def options

--- a/lib/yuriita/single_collection.rb
+++ b/lib/yuriita/single_collection.rb
@@ -7,11 +7,9 @@ module Yuriita
     end
 
     def apply(relation)
-      if selected_option.present?
-        selected_option.filter.apply(relation)
-      else
-        relation
-      end
+      return relation if active_filter.nil?
+
+      active_filter.apply(relation)
     end
 
     def view_options
@@ -35,8 +33,8 @@ module Yuriita
     end
 
     def selected?(option)
-      if selected_option.present?
-        selected_option == option
+      if active_option.present?
+        active_option == option
       else
         false
       end
@@ -62,7 +60,13 @@ module Yuriita
       end
     end
 
-    def selected_option
+    def active_filter
+      if active_option.present?
+        active_option.filter
+      end
+    end
+
+    def active_option
       input = last_matching_input
       if input.present?
         option_for(input)

--- a/spec/example_app/app/models/movie_definition.rb
+++ b/spec/example_app/app/models/movie_definition.rb
@@ -30,7 +30,7 @@ class MovieDefinition
 
   def title_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "title"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "title"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:title, term)
@@ -41,7 +41,7 @@ class MovieDefinition
 
   def tagline_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "tagline"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "tagline"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:tagline, term)
@@ -52,7 +52,7 @@ class MovieDefinition
 
   def overview_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "overview"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "overview"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:overview, term)
@@ -79,7 +79,7 @@ class MovieDefinition
 
   def rumored_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "rumored"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "rumored"),
     ) do |relation|
       relation.rumored
     end
@@ -89,7 +89,7 @@ class MovieDefinition
 
   def released_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "released"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "released"),
     ) do |relation|
       relation.released
     end
@@ -99,7 +99,7 @@ class MovieDefinition
 
   def post_production_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "post_production"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "post_production"),
     ) do |relation|
       relation.post_production
     end
@@ -109,7 +109,7 @@ class MovieDefinition
 
   def cancelled_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "cancelled"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "cancelled"),
     ) do |relation|
       relation.cancelled
     end
@@ -123,7 +123,7 @@ class MovieDefinition
 
   def adult_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "adult"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "adult"),
     ) do |relation|
       relation.where(adult: true)
     end
@@ -133,7 +133,7 @@ class MovieDefinition
 
   def safe_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "safe"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "safe"),
     ) do |relation|
       relation.where(adult: false)
     end
@@ -154,7 +154,7 @@ class MovieDefinition
 
   def rating_sort_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "sort", term: "default"),
+      input: Yuriita::Query::Input.new(qualifier: "sort", term: "default"),
     ) do |relation|
       relation.order(vote_average: :desc)
     end
@@ -164,7 +164,7 @@ class MovieDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "sort", term: "title-desc"),
+      input: Yuriita::Query::Input.new(qualifier: "sort", term: "title-desc"),
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -174,7 +174,7 @@ class MovieDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "sort", term: "title-asc"),
+      input: Yuriita::Query::Input.new(qualifier: "sort", term: "title-asc"),
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -34,7 +34,7 @@ class PostDefinition
 
   def title_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "title"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "title"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:title, term)
@@ -45,7 +45,7 @@ class PostDefinition
 
   def body_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "body"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "body"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:body, term)
@@ -56,7 +56,7 @@ class PostDefinition
 
   def description_option
     filter = Yuriita::SearchFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "in", term: "description"),
+      input: Yuriita::Query::Input.new(qualifier: "in", term: "description"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:description, term)
@@ -78,7 +78,7 @@ class PostDefinition
 
   def published_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "published"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "published"),
     ) do |relation|
       relation.published
     end
@@ -88,7 +88,7 @@ class PostDefinition
 
   def draft_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "is", term: "draft"),
+      input: Yuriita::Query::Input.new(qualifier: "is", term: "draft"),
     ) do |relation|
       relation.draft
     end
@@ -107,7 +107,7 @@ class PostDefinition
     Category.find_each.map do |category|
       name = category.name
       filter = Yuriita::ExpressionFilter.new(
-        matcher: Yuriita::Matchers::Expression.new(qualifier: "category", term: name),
+        input: Yuriita::Query::Input.new(qualifier: "category", term: name),
       ) do |relation|
         relation.joins(:categories).where(categories: { name: name })
       end
@@ -129,7 +129,7 @@ class PostDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "sort", term: "title-desc"),
+      input: Yuriita::Query::Input.new(qualifier: "sort", term: "title-desc"),
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -139,7 +139,7 @@ class PostDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      matcher: Yuriita::Matchers::Expression.new(qualifier: "sort", term: "title-asc"),
+      input: Yuriita::Query::Input.new(qualifier: "sort", term: "title-asc"),
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe Yuriita::Query do
     end
   end
 
+  describe "#delete" do
+    it "removes an input from the query" do
+      published = build(:input, qualifier: "is", term: "published")
+      draft = build(:input, qualifier: "is", term: "draft")
+      query = described_class.new(inputs: [published, draft])
+
+      query.delete(published)
+
+      expect(query).not_to include(published)
+      expect(query).to include(draft)
+    end
+  end
+
   describe "#include?" do
     it "is true if the query contains the input" do
       published = build(:input, qualifier: "is", term: "published")


### PR DESCRIPTION
Having a notion of matching was making it hard to understand when to add
or remove inputs from the query when building the params.

This commit removes the expression filter and search filter `matcher`
argument. It's replaced with an `input` argument. This input is used to
determine if an option is selected. It's also used to generate the new
query when an option is selected.