### PR TITLE
Load factories in library specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "yuriita"
-require "factory_bot_rails"
+require "factory_bot"
 
 RSpec.configure do |config|
 

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,5 @@
+FactoryBot.find_definitions
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
When running specs that do not require the rails app to be loaded, only
the `spec_helper` file is required. This file is required automatically
by RSpec via the `.rspec` configuration file.

FactoryBot does not automatically load factory definitions without
Rails. This commit ensures that the definitions are loaded even when the
Rails app isn't booted so we can access factories that build library
objects such as inputs, options, filters, and queries.