### PR TITLE
Combine inputs and keywords to maintain order

### DIFF
--- a/lib/yuriita/assembler.rb
+++ b/lib/yuriita/assembler.rb
@@ -1,26 +1,14 @@
 module Yuriita
   class Assembler
+    attr_reader :configuration
+
     def initialize(configuration)
       @configuration = configuration
     end
 
     def build(query)
-      expression_clauses(query) + search_clauses(query)
-    end
-
-    private
-
-    attr_reader :configuration
-
-    def expression_clauses(query)
       configuration.definitions.each_value.map do |definition|
         definition.apply(query: query)
-      end
-    end
-
-    def search_clauses(query)
-      configuration.scopes.each_value.map do |collection|
-        collection.apply(query: query)
       end
     end
   end

--- a/lib/yuriita/configuration.rb
+++ b/lib/yuriita/configuration.rb
@@ -1,10 +1,9 @@
 module Yuriita
   class Configuration
-    attr_reader :definitions, :scopes
+    attr_reader :definitions
 
-    def initialize(definitions: {}, scopes: {})
+    def initialize(definitions)
       @definitions = definitions
-      @scopes = scopes
     end
 
     def find_definition(key)

--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -7,7 +7,6 @@ module Yuriita
     production(:query) do
       clause("SPACE? .fragment SPACE?") do |fragment|
         Query.new(
-          keywords: fragment.keywords,
           inputs: fragment.inputs,
         )
       end
@@ -16,7 +15,7 @@ module Yuriita
 
     production(:fragment) do
       clause(".keyword") do |keyword|
-        Query::Fragment.new(keywords: [keyword])
+        Query::Fragment.new(inputs: [keyword])
       end
       clause(".search_input") do |search_input|
         Query::Fragment.new(inputs: [search_input])

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -8,6 +8,10 @@ module Yuriita
       @inputs = inputs
     end
 
+    def keywords
+      inputs.reject{ |input| input.is_a?(Query::Input) }
+    end
+
     def each(&block)
       block or return enum_for(__method__) { size }
       inputs.each(&block)

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -2,23 +2,15 @@ module Yuriita
   class Query
     include Enumerable
 
-    attr_reader :keywords, :inputs
+    attr_reader :inputs
 
-    def initialize(keywords: [], inputs: [])
-      @keywords = keywords
+    def initialize(inputs: [])
       @inputs = inputs
     end
 
     def each(&block)
       block or return enum_for(__method__) { size }
       inputs.each(&block)
-      self
-    end
-
-    def each_element(&block)
-      block or return enum_for(__method__) { size + keywords.size }
-      elements = inputs + keywords
-      elements.each(&block)
       self
     end
 

--- a/lib/yuriita/query/fragment.rb
+++ b/lib/yuriita/query/fragment.rb
@@ -1,16 +1,14 @@
 module Yuriita
   class Query
     class Fragment
-      attr_reader :keywords, :inputs
+      attr_reader :inputs
 
-      def initialize(keywords: [], inputs: [])
-        @keywords = keywords
+      def initialize(inputs: [])
         @inputs = inputs
       end
 
       def merge(other)
         Fragment.new(
-          keywords: keywords + other.keywords,
           inputs: inputs + other.inputs,
         )
       end

--- a/lib/yuriita/query_formatter.rb
+++ b/lib/yuriita/query_formatter.rb
@@ -7,7 +7,7 @@ module Yuriita
     end
 
     def format(query)
-      value = query.each_element.map(&:to_s).join(SPACE)
+      value = query.each.map(&:to_s).join(SPACE)
       { param_key => value }
     end
 

--- a/lib/yuriita/search_collection.rb
+++ b/lib/yuriita/search_collection.rb
@@ -41,7 +41,7 @@ module Yuriita
     end
 
     def keywords
-      query.keywords
+      query.inputs.reject{|input| input.is_a?  Query::Input}
     end
   end
 end

--- a/lib/yuriita/search_collection.rb
+++ b/lib/yuriita/search_collection.rb
@@ -41,7 +41,7 @@ module Yuriita
     end
 
     def keywords
-      query.inputs.reject{|input| input.is_a?  Query::Input}
+      query.keywords
     end
   end
 end

--- a/spec/example_app/app/models/movie_definition.rb
+++ b/spec/example_app/app/models/movie_definition.rb
@@ -4,17 +4,18 @@ class MovieDefinition
   end
 
   def build
-    Yuriita::Configuration.new(definitions: definitions, scopes: scopes)
+    Yuriita::Configuration.new(definitions)
   end
 
   private
 
-  def scopes
-    { movie: movie_scope }
-  end
-
   def definitions
-    { status: status_definition, adult: adult_definition, sort: sort_definition }
+    {
+      status: status_definition,
+      adult: adult_definition,
+      sort: sort_definition,
+      movie: movie_scope,
+    }
   end
 
   def movie_scope

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -4,20 +4,17 @@ class PostDefinition
   end
 
   def build
-    Yuriita::Configuration.new(definitions: definitions, scopes: scopes)
+    Yuriita::Configuration.new(definitions)
   end
 
   private
-
-  def scopes
-    { post: post_scope }
-  end
 
   def definitions
     {
       published: published_definition,
       category: category_definition,
       sort: sort_definition,
+      post: post_scope,
     }
   end
 

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -3,14 +3,13 @@ RSpec.describe Yuriita::Parser do
     it "parses an empty string" do
       query = parse(tokens([:EOS]))
 
-      expect(query.keywords).to eq []
       expect(query.inputs).to eq []
     end
 
     it "parses keywords" do
       query = parse(tokens([:WORD, "hello"], [:EOS]))
 
-      expect(query.keywords).to eq ["hello"]
+      expect(query.inputs).to eq ["hello"]
     end
 
     it "parses a keyword with an expression_input" do
@@ -21,9 +20,9 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-      expect(query.keywords).to eq ["hello"]
       expect(query.inputs).to contain_exactly(
-        an_input_matching("label", "bug")
+        an_input_matching("label", "bug"),
+        "hello"
       )
     end
 
@@ -35,7 +34,7 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-      expect(query.keywords).to eq ["hello world"]
+      expect(query.inputs).to eq ["hello world"]
     end
 
     it "parses keywords with an expression_input between them" do
@@ -48,9 +47,10 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-      expect(query.keywords).to eq ["hello", "world"]
       expect(query.inputs).to contain_exactly(
-        an_input_matching("label", "bug")
+        an_input_matching("label", "bug"), 
+        "hello",
+        "world",
       )
     end
 
@@ -66,11 +66,11 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-
-      expect(query.keywords).to eq ["hello", "world"]
       expect(query.inputs).to contain_exactly(
         an_input_matching("label", "bug"),
-        an_input_matching("label", "security")
+        an_input_matching("label", "security"),
+        "hello",
+        "world",
       )
     end
 
@@ -92,11 +92,14 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-      expect(query.keywords).to eq ["hello", "world", "search", "term"]
       expect(query.inputs).to contain_exactly(
         an_input_matching("label", "red"),
         an_input_matching("label", "blue"),
         an_input_matching("label", "green"),
+        "hello",
+        "world",
+        "search",
+        "term",
       )
     end
 
@@ -187,9 +190,10 @@ RSpec.describe Yuriita::Parser do
         [:EOS],
       ))
 
-      expect(query.keywords).to eq ["awesome", "ideas"]
       expect(query.inputs).to contain_exactly(
-        an_input_matching("in", "title")
+        an_input_matching("in", "title"),
+        "awesome",
+        "ideas",
       )
     end
   end

--- a/spec/yuriita/query_formatter_spec.rb
+++ b/spec/yuriita/query_formatter_spec.rb
@@ -1,13 +1,12 @@
 RSpec.describe Yuriita::QueryFormatter do
   describe "#format" do
-    it "returns a an input string keyed by the param_key" do
-      published = build(:input, qualifier: "is", term: "published")
-      title = build(:input, qualifier: "in", term: "title")
-      query = Yuriita::Query.new(inputs: [published, title], keywords: ["cats"])
+    it "returns a an ordered input string keyed by the param_key" do
+      string = "cats in:title is:published"
+      query =Yuriita::QueryBuilder.build(string)
 
       formatted = described_class.new(param_key: :q).format(query)
 
-      expect(formatted).to eq({ q: "is:published in:title cats" })
+      expect(formatted).to eq({ q: "cats in:title is:published" })
     end
 
     it "returns an empty string when the query is empty" do

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -1,13 +1,4 @@
 RSpec.describe Yuriita::Query do
-  describe "#keywords" do
-    it "returns the initialized keywords" do
-      keywords = double(:keywords)
-      query = described_class.new(keywords: keywords)
-
-      expect(query.keywords).to eq keywords
-    end
-  end
-
   describe "#inputs" do
     it "returns the initialized" do
       inputs = double(:inputs)
@@ -54,18 +45,6 @@ RSpec.describe Yuriita::Query do
       expect do |b|
         query.each(&b)
       end.to yield_successive_args(published, draft)
-    end
-  end
-
-  describe "#each_element" do
-    it "yields inputs and keywords" do
-      published = build(:input, qualifier: "is", term: "published")
-      draft = build(:input, qualifier: "is", term: "draft")
-      query = described_class.new(inputs: [published, draft], keywords: ["cat"])
-
-      expect do |b|
-        query.each_element(&b)
-      end.to yield_successive_args(published, draft, "cat")
     end
   end
 

--- a/spec/yuriita/query_spec.rb
+++ b/spec/yuriita/query_spec.rb
@@ -1,10 +1,27 @@
 RSpec.describe Yuriita::Query do
-  describe "#inputs" do
-    it "returns the initialized" do
-      inputs = double(:inputs)
-      query = described_class.new(inputs: inputs)
+  describe "#keywords" do
+    it "returns only keywords" do
+      active = build(:input, qualifier: "is", term: "active")
+      author = build(:input, qualifier: "author", term: "eebs")
 
-      expect(query.inputs).to eq inputs
+      query = described_class.new(
+        inputs: [active, "keyword", author]
+      )
+
+      expect(query.keywords).to eq ["keyword"]
+    end
+  end
+
+  describe "#inputs" do
+    it "returns all items" do
+      active = build(:input, qualifier: "is", term: "active")
+      author = build(:input, qualifier: "author", term: "eebs")
+
+      query = described_class.new(
+        inputs: [active, "keyword", author]
+      )
+
+      expect(query.inputs).to eq [active, "keyword", author]
     end
   end
 


### PR DESCRIPTION
Splitting a query's terms into inputs and keywords makes it difficult to
maintain the original order when turning a query back into a string.  In
investigating this, it became clear that the distinction between
keywords and inputs was only necessary when performing the search. When
searching, keywords can be separated from inputs by checking to see if
an item is an input object, then only searching on items that are not
(we could also check to see if it is a string, and only search the
strings).

This combines keywords and inputs into one array in a query or
configuration. This maintains the order, so when a query is converted
back to a string, the user sees the string they originally submitted.

All original specs pass, and the query formatter spec now returns a string ordered the same as the original string. I'm wondering if I missed something else that makes it necessary to keep inputs and keywords separate. If this does work, it's possible that there are further simplifications we can make now that we don't need separate arrays for these.