### PR TITLE
Extract selector objects from collections

### DIFF
--- a/lib/yuriita/exclusive_select.rb
+++ b/lib/yuriita/exclusive_select.rb
@@ -1,0 +1,46 @@
+module Yuriita
+  class ExclusiveSelect
+    def initialize(options:, default:, query:)
+      @options = options
+      @default = default
+      @query = query
+    end
+
+    def filter
+      active_option.filter
+    end
+
+    def selected?(option)
+      active_option == option
+    end
+
+    private
+
+    attr_reader :options, :default, :query
+
+    def active_option
+      chosen_option || default
+    end
+
+    def chosen_option
+      input = last_matching_input
+      if input.present?
+        option_for(input)
+      end
+    end
+
+    def last_matching_input
+      matching_inputs.last
+    end
+
+    def matching_inputs
+      query.select do |input|
+        options.any? { |option| option.input == input }
+      end
+    end
+
+    def option_for(input)
+      options.detect { |option| option.input == input }
+    end
+  end
+end

--- a/lib/yuriita/multi_select.rb
+++ b/lib/yuriita/multi_select.rb
@@ -1,0 +1,30 @@
+module Yuriita
+  class MultiSelect
+    def initialize(options:, query:)
+      @options = options
+      @query = query
+    end
+
+    def filters
+      active_options.map(&:filter)
+    end
+
+    def selected?(option)
+      active_options.include?(option)
+    end
+
+    def empty?
+      filters.empty?
+    end
+
+    private
+
+    attr_reader :options, :query
+
+    def active_options
+      options.select do |option|
+        query.include?(option.input)
+      end
+    end
+  end
+end

--- a/lib/yuriita/multiple_collection.rb
+++ b/lib/yuriita/multiple_collection.rb
@@ -7,9 +7,9 @@ module Yuriita
     end
 
     def apply(relation)
-      return relation if active_filters.empty?
+      return relation if selector.empty?
 
-      relations = active_filters.map { |filter| filter.apply(relation) }
+      relations = selector.filters.map { |filter| filter.apply(relation) }
 
       definition.combination.new(
         base_relation: relation,
@@ -32,13 +32,9 @@ module Yuriita
     def view_option(option)
       ViewOption.new(
         name: option.name,
-        selected: selected?(option),
+        selected: selector.selected?(option),
         params: params(option),
       )
-    end
-
-    def selected?(option)
-      active_options.include?(option)
     end
 
     def params(option)
@@ -46,7 +42,7 @@ module Yuriita
     end
 
     def build_query(option)
-      if selected?(option)
+      if selector.selected?(option)
         option_query = query.dup
         option_query.delete(option.input)
       else
@@ -55,18 +51,12 @@ module Yuriita
       end
     end
 
-    def active_filters
-      active_options.map(&:filter)
-    end
-
-    def active_options
-      options.select do |option|
-        query.include?(option.input)
-      end
-    end
-
     def options
       definition.options
+    end
+
+    def selector
+      MultiSelect.new(options: options, query: query)
     end
   end
 end

--- a/lib/yuriita/option.rb
+++ b/lib/yuriita/option.rb
@@ -10,5 +10,10 @@ module Yuriita
     def input
       filter.input
     end
+
+    def ==(other)
+      other.is_a?(self.class) && other.name == name
+    end
+    alias_method :eql?, :==
   end
 end

--- a/lib/yuriita/single_collection.rb
+++ b/lib/yuriita/single_collection.rb
@@ -7,9 +7,9 @@ module Yuriita
     end
 
     def apply(relation)
-      return relation if active_filter.nil?
+      return relation if selector.empty?
 
-      active_filter.apply(relation)
+      selector.filter.apply(relation)
     end
 
     def view_options
@@ -27,17 +27,9 @@ module Yuriita
     def view_option(option)
       ViewOption.new(
         name: option.name,
-        selected: selected?(option),
+        selected: selector.selected?(option),
         params: params(option),
       )
-    end
-
-    def selected?(option)
-      if active_option.present?
-        active_option == option
-      else
-        false
-      end
     end
 
     def params(option)
@@ -45,7 +37,7 @@ module Yuriita
     end
 
     def build_query(option)
-      if selected?(option)
+      if selector.selected?(option)
         option_query = query.dup
         matching_inputs.each do |input|
           option_query.delete(input)
@@ -60,27 +52,6 @@ module Yuriita
       end
     end
 
-    def active_filter
-      if active_option.present?
-        active_option.filter
-      end
-    end
-
-    def active_option
-      input = last_matching_input
-      if input.present?
-        option_for(input)
-      end
-    end
-
-    def last_matching_input
-      matching_inputs.last
-    end
-
-    def option_for(input)
-      options.detect { |option| option.input == input }
-    end
-
     def matching_inputs
       query.select do |input|
         options.any? { |option| option.input == input }
@@ -89,6 +60,10 @@ module Yuriita
 
     def options
       definition.options
+    end
+
+    def selector
+      SingleSelect.new(options: options, query: query)
     end
   end
 end

--- a/lib/yuriita/single_select.rb
+++ b/lib/yuriita/single_select.rb
@@ -1,0 +1,51 @@
+module Yuriita
+  class SingleSelect
+    def initialize(options:, query:)
+      @options = options
+      @query = query
+    end
+
+    def filter
+      if active_option.present?
+        active_option.filter
+      end
+    end
+
+    def selected?(option)
+      if active_option.present?
+        active_option == option
+      else
+        false
+      end
+    end
+
+    def empty?
+      filter.nil?
+    end
+
+    private
+
+    attr_reader :options, :query
+
+    def active_option
+      input = last_matching_input
+      if input.present?
+        option_for(input)
+      end
+    end
+
+    def last_matching_input
+      matching_inputs.last
+    end
+
+    def matching_inputs
+      query.select do |input|
+        options.any? { |option| option.input == input }
+      end
+    end
+
+    def option_for(input)
+      options.detect { |option| option.input == input }
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,14 @@ FactoryBot.define do
     end
   end
 
+  factory :query, class: "Yuriita::Query" do
+    skip_create
+
+    inputs { [] }
+
+    initialize_with { new(attributes) }
+  end
+
   factory :input, class: "Yuriita::Query::Input" do
     skip_create
 
@@ -58,6 +66,24 @@ FactoryBot.define do
     term { "published" }
 
     initialize_with { new(attributes) }
+  end
+
+  factory :option, class: "Yuriita::Option" do
+    skip_create
+
+    name { "Option Name" }
+    filter { build(:expression_filter) }
+
+    initialize_with { new(attributes) }
+  end
+
+  factory :expression_filter, class: "Yuriita::ExpressionFilter" do
+    skip_create
+
+    input
+    block { ->(relation) { relation } }
+
+    initialize_with { new(input: input, &block) }
   end
 
   factory :genre do

--- a/spec/yuriita/exclusive_select_spec.rb
+++ b/spec/yuriita/exclusive_select_spec.rb
@@ -1,0 +1,136 @@
+RSpec.describe Yuriita::ExclusiveSelect do
+  describe "filter" do
+    context "when there are no selected options" do
+      it "returns the default option's filter" do
+        active_input = build(:input, qualifier: "is", term: "active")
+        active_filter = build(:expression_filter, input: active_input)
+        active_option = build(:option, name: "Active", filter: active_filter)
+        hidden_input = build(:input, qualifier: "is", term: "hidden")
+        hidden_filter = build(:expression_filter, input: hidden_input)
+        hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+
+        query = build(:query, inputs: [])
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: active_option,
+          query: query,
+        )
+
+        expect(selector.filter).to eq active_filter
+      end
+    end
+
+    context "when there is a selected option" do
+      it "returns the selected option's filter" do
+        active_input = build(:input, qualifier: "is", term: "active")
+        active_filter = build(:expression_filter, input: active_input)
+        active_option = build(:option, name: "Active", filter: active_filter)
+        hidden_input = build(:input, qualifier: "is", term: "hidden")
+        hidden_filter = build(:expression_filter, input: hidden_input)
+        hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+
+        query = build(
+          :query,
+          inputs: [build(:input, qualifier: "is", term: "active")],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: hidden_option,
+          query: query,
+        )
+
+        expect(selector.filter).to eq active_filter
+      end
+    end
+  end
+
+  describe "#selected?" do
+    context "when the there are no inputs" do
+      it "the default option is select" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(:query, inputs: [])
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: active_option,
+          query: query,
+        )
+        result = selector.selected?(active_option)
+
+        expect(result).to be true
+      end
+
+      it "non-default options are not selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(:query, inputs: [])
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: active_option,
+          query: query,
+        )
+        result = selector.selected?(hidden_option)
+
+        expect(result).to be false
+      end
+    end
+
+    context "when the option's input is in the query" do
+      it "the option is selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(
+          :query,
+          inputs: [build(:input, qualifier: "is", term: "active")],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: hidden_option,
+          query: query,
+        )
+        result = selector.selected?(active_option)
+
+        expect(result).to be true
+      end
+    end
+
+    context "when multiple matching inputs are present" do
+      it "the option matching the last matched input is selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(
+          :query,
+          inputs: [
+            build(:input, qualifier: "is", term: "hidden"),
+            build(:input, qualifier: "is", term: "active"),
+          ],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          default: hidden_option,
+          query: query,
+        )
+        active_selected = selector.selected?(active_option)
+        hidden_selected = selector.selected?(hidden_option)
+
+        expect(active_selected).to be true
+        expect(hidden_selected).to be false
+      end
+    end
+  end
+
+  def build_option(name, qualifier, term)
+    input = build(:input, qualifier: qualifier, term: term)
+    build(:option, name: name, filter: build(:expression_filter, input: input))
+  end
+end

--- a/spec/yuriita/multi_select_spec.rb
+++ b/spec/yuriita/multi_select_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe Yuriita::MultiSelect do
+  describe "filters" do
+    it "returns the selected option's filters" do
+      active_input = build(:input, qualifier: "is", term: "active")
+      active_filter = build(:expression_filter, input: active_input)
+      active_option = build(:option, name: "Active", filter: active_filter)
+      hidden_input = build(:input, qualifier: "is", term: "hidden")
+      hidden_filter = build(:expression_filter, input: hidden_input)
+      hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "is", term: "active")],
+      )
+
+      selector = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+      )
+
+      expect(selector.filters).to eq [active_filter]
+    end
+  end
+
+  describe "#selected?" do
+    it "returns true if the given option's input is in the query" do
+      active_option = build_option("Active", "is", "active")
+      hidden_option = build_option("Hidden", "is", "hidden")
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "is", term: "active")],
+      )
+
+      selector = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+      )
+      result = selector.selected?(active_option)
+
+      expect(result).to be true
+    end
+
+    it "returns false if the given option's input is not in the query" do
+      active_option = build_option("Active", "is", "active")
+      hidden_option = build_option("Hidden", "is", "hidden")
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "is", term: "active")],
+      )
+
+      selector = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+      )
+      result = selector.selected?(hidden_option)
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true when none of the options match the query" do
+      active_option = build_option("Active", "is", "active")
+      hidden_option = build_option("Hidden", "is", "hidden")
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "author", term: "eebs")],
+      )
+
+      selector = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+      )
+
+      expect(selector).to be_empty
+    end
+  end
+
+  def build_option(name, qualifier, term)
+    input = build(:input, qualifier: qualifier, term: term)
+    build(:option, name: name, filter: build(:expression_filter, input: input))
+  end
+end

--- a/spec/yuriita/option_spec.rb
+++ b/spec/yuriita/option_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Yuriita::Option do
+  it "equality is based on the option's name" do
+    filter = double(:filter)
+    option_a = described_class.new(name: "One", filter: filter)
+    option_b = described_class.new(name: "One", filter: filter)
+    option_c = described_class.new(name: "Two", filter: filter)
+
+    expect(option_a).to eq(option_a)
+    expect(option_a).to eq(option_b)
+    expect(option_a).not_to eq(option_c)
+  end
+end

--- a/spec/yuriita/single_select_spec.rb
+++ b/spec/yuriita/single_select_spec.rb
@@ -1,0 +1,136 @@
+RSpec.describe Yuriita::SingleSelect do
+  describe "filter" do
+    context "when there are no selected options" do
+      it "returns the selected option's filter" do
+        active_input = build(:input, qualifier: "is", term: "active")
+        active_filter = build(:expression_filter, input: active_input)
+        active_option = build(:option, name: "Active", filter: active_filter)
+        hidden_input = build(:input, qualifier: "is", term: "hidden")
+        hidden_filter = build(:expression_filter, input: hidden_input)
+        hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+
+        query = build(
+          :query,
+          inputs: [build(:input, qualifier: "author", term: "eebs")],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          query: query,
+        )
+
+        expect(selector.filter).to be nil
+      end
+    end
+
+    context "when there is a selected option" do
+      it "returns the selected option's filter" do
+        active_input = build(:input, qualifier: "is", term: "active")
+        active_filter = build(:expression_filter, input: active_input)
+        active_option = build(:option, name: "Active", filter: active_filter)
+        hidden_input = build(:input, qualifier: "is", term: "hidden")
+        hidden_filter = build(:expression_filter, input: hidden_input)
+        hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+
+        query = build(
+          :query,
+          inputs: [build(:input, qualifier: "is", term: "active")],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          query: query,
+        )
+
+        expect(selector.filter).to eq active_filter
+      end
+    end
+  end
+
+  describe "#selected?" do
+    context "when the there are no inputs" do
+      it "the option is not selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(:query, inputs: [])
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          query: query,
+        )
+        result = selector.selected?(active_option)
+
+        expect(result).to be false
+      end
+    end
+
+    context "when the option's input is in the query" do
+      it "the option is selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(
+          :query,
+          inputs: [build(:input, qualifier: "is", term: "active")],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          query: query,
+        )
+        result = selector.selected?(active_option)
+
+        expect(result).to be true
+      end
+    end
+
+    context "when multiple matching inputs are present" do
+      it "the option matching the last matched input is selected" do
+        active_option = build_option("Active", "is", "active")
+        hidden_option = build_option("Hidden", "is", "hidden")
+
+        query = build(
+          :query,
+          inputs: [
+            build(:input, qualifier: "is", term: "hidden"),
+            build(:input, qualifier: "is", term: "active"),
+          ],
+        )
+
+        selector = described_class.new(
+          options: [active_option, hidden_option],
+          query: query,
+        )
+        active_selected = selector.selected?(active_option)
+        hidden_selected = selector.selected?(hidden_option)
+
+        expect(active_selected).to be true
+        expect(hidden_selected).to be false
+      end
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true when none of the options match the query" do
+      active_option = build_option("Active", "is", "active")
+      hidden_option = build_option("Hidden", "is", "hidden")
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "author", term: "eebs")],
+      )
+
+      selector = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+      )
+
+      expect(selector).to be_empty
+    end
+  end
+
+  def build_option(name, qualifier, term)
+    input = build(:input, qualifier: qualifier, term: term)
+    build(:option, name: name, filter: build(:expression_filter, input: input))
+  end
+end


### PR DESCRIPTION
This commit refactors the collection options to extract the selection
behavior for each of them.

This commit also fixes a TODO item which was to make Option equality
based on name rather than object identity. This allows us to define an
exexclusive collection with a default, and if no option is selected via
an input the default option is selected.