### PR TITLE
Extract parameters objects for building params

### DIFF
--- a/lib/yuriita/exclusive_collection.rb
+++ b/lib/yuriita/exclusive_collection.rb
@@ -7,6 +7,11 @@ module Yuriita
     end
 
     def apply(relation)
+      selector = ExclusiveSelect.new(
+        options: options,
+        default: definition.default,
+        query: query,
+      )
       selector.filter.apply(relation)
     end
 
@@ -24,48 +29,22 @@ module Yuriita
 
     def view_option(option)
       ViewOption.new(
-        name: option.name,
-        selected: selector.selected?(option),
-        params: params(option),
+        option: option,
+        selector: ExclusiveSelect.new(
+          options: options,
+          default: definition.default,
+          query: query,
+        ),
+        parameters: SingleParameter.new(
+          options: options,
+          query: query.dup,
+          formatter: formatter,
+        ),
       )
-    end
-
-    def params(option)
-      formatter.format build_query(option)
-    end
-
-    def build_query(option)
-      if selector.selected?(option)
-        option_query = query.dup
-        matching_inputs.each do |input|
-          option_query.delete(input)
-        end
-        option_query
-      else
-        option_query = query.dup
-        matching_inputs.each do |input|
-          option_query.delete(input)
-        end
-        option_query << option.input
-      end
-    end
-
-    def matching_inputs
-      query.select do |input|
-        options.any? { |option| option.input == input }
-      end
     end
 
     def options
       definition.options
-    end
-
-    def selector
-      ExclusiveSelect.new(
-        options: options,
-        default: definition.default,
-        query: query,
-      )
     end
   end
 end

--- a/lib/yuriita/multi_parameter.rb
+++ b/lib/yuriita/multi_parameter.rb
@@ -1,0 +1,24 @@
+module Yuriita
+  class MultiParameter
+    def initialize(query:, formatter:)
+      @query = query
+      @formatter = formatter
+    end
+
+    def select(input)
+      format(query << input)
+    end
+
+    def deselect(input)
+      format(query.delete(input))
+    end
+
+    private
+
+    attr_reader :option, :query, :formatter
+
+    def format(query)
+      formatter.format(query)
+    end
+  end
+end

--- a/lib/yuriita/multiple_collection.rb
+++ b/lib/yuriita/multiple_collection.rb
@@ -7,6 +7,7 @@ module Yuriita
     end
 
     def apply(relation)
+      selector = MultiSelect.new(options: options, query: query)
       return relation if selector.empty?
 
       relations = selector.filters.map { |filter| filter.apply(relation) }
@@ -31,32 +32,14 @@ module Yuriita
 
     def view_option(option)
       ViewOption.new(
-        name: option.name,
-        selected: selector.selected?(option),
-        params: params(option),
+        option: option,
+        selector: MultiSelect.new(options: options, query: query),
+        parameters: MultiParameter.new(query: query.dup, formatter: formatter),
       )
-    end
-
-    def params(option)
-      formatter.format build_query(option)
-    end
-
-    def build_query(option)
-      if selector.selected?(option)
-        option_query = query.dup
-        option_query.delete(option.input)
-      else
-        option_query = query.dup
-        option_query << option.input
-      end
     end
 
     def options
       definition.options
-    end
-
-    def selector
-      MultiSelect.new(options: options, query: query)
     end
   end
 end

--- a/lib/yuriita/single_collection.rb
+++ b/lib/yuriita/single_collection.rb
@@ -7,6 +7,7 @@ module Yuriita
     end
 
     def apply(relation)
+      selector = SingleSelect.new(options: options, query: query)
       return relation if selector.empty?
 
       selector.filter.apply(relation)
@@ -26,44 +27,18 @@ module Yuriita
 
     def view_option(option)
       ViewOption.new(
-        name: option.name,
-        selected: selector.selected?(option),
-        params: params(option),
+        option: option,
+        selector: SingleSelect.new(options: options, query: query),
+        parameters: SingleParameter.new(
+          options: options,
+          query: query.dup,
+          formatter: formatter,
+        ),
       )
-    end
-
-    def params(option)
-      formatter.format build_query(option)
-    end
-
-    def build_query(option)
-      if selector.selected?(option)
-        option_query = query.dup
-        matching_inputs.each do |input|
-          option_query.delete(input)
-        end
-        option_query
-      else
-        option_query = query.dup
-        matching_inputs.each do |input|
-          option_query.delete(input)
-        end
-        option_query << option.input
-      end
-    end
-
-    def matching_inputs
-      query.select do |input|
-        options.any? { |option| option.input == input }
-      end
     end
 
     def options
       definition.options
-    end
-
-    def selector
-      SingleSelect.new(options: options, query: query)
     end
   end
 end

--- a/lib/yuriita/single_parameter.rb
+++ b/lib/yuriita/single_parameter.rb
@@ -1,0 +1,37 @@
+module Yuriita
+  class SingleParameter
+    def initialize(options:, query:, formatter:)
+      @options = options
+      @query = query
+      @formatter = formatter
+    end
+
+    def select(input)
+      matching_inputs.each do |input|
+        query.delete(input)
+      end
+      format(query << input)
+    end
+
+    def deselect(input)
+      matching_inputs.each do |input|
+        query.delete(input)
+      end
+      format(query)
+    end
+
+    private
+
+    attr_reader :options, :query, :formatter
+
+    def format(query)
+      formatter.format(query)
+    end
+
+    def matching_inputs
+      query.select do |input|
+        options.any? { |option| option.input == input }
+      end
+    end
+  end
+end

--- a/lib/yuriita/view_option.rb
+++ b/lib/yuriita/view_option.rb
@@ -1,15 +1,30 @@
 module Yuriita
   class ViewOption
-    attr_reader :name, :selected, :params
 
-    def initialize(name:, selected:, params:)
-      @name = name
-      @selected = selected
-      @params = params
+    def initialize(option:, selector:, parameters:)
+      @option = option
+      @selector = selector
+      @parameters = parameters
+    end
+
+    def name
+      option.name
     end
 
     def selected?
-      selected
+      selector.selected?(option)
     end
+
+    def params
+      if selected?
+        parameters.deselect(option.input)
+      else
+        parameters.select(option.input)
+      end
+    end
+
+    private
+
+    attr_reader :option, :selector, :parameters
   end
 end

--- a/spec/yuriita/multi_parameter_spec.rb
+++ b/spec/yuriita/multi_parameter_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Yuriita::MultiParameter do
+  describe "#select" do
+    it "adds the input to the query" do
+      active_input = build(:input, qualifier: "is", term: "active")
+      author_input = build(:input, qualifier: "author", term: "eebs")
+      query = Yuriita::Query.new(inputs: [active_input])
+
+      formatter = Yuriita::QueryFormatter.new(param_key: :q)
+      parameters = described_class.new(query: query, formatter: formatter)
+      result = parameters.select(author_input)
+
+      expect(result).to eq({ q: "is:active author:eebs" })
+    end
+  end
+
+  describe "#deselect" do
+    it "removes the input from the query" do
+      active_input = build(:input, qualifier: "is", term: "active")
+      author_input = build(:input, qualifier: "author", term: "eebs")
+      query = Yuriita::Query.new(inputs: [active_input, author_input])
+
+      formatter = Yuriita::QueryFormatter.new(param_key: :q)
+      parameters = described_class.new(query: query, formatter: formatter)
+      result = parameters.deselect(author_input)
+
+      expect(result).to eq({ q: "is:active" })
+    end
+  end
+end

--- a/spec/yuriita/single_parameter_spec.rb
+++ b/spec/yuriita/single_parameter_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Yuriita::SingleParameter do
+  describe "#select" do
+    it "replaces existing inputs in the query with the new input" do
+      active_input = build(:input, qualifier: "is", term: "active")
+      active_filter = build(:expression_filter, input: active_input)
+      active_option = build(:option, name: "Active", filter: active_filter)
+      hidden_input = build(:input, qualifier: "is", term: "hidden")
+      hidden_filter = build(:expression_filter, input: hidden_input)
+      hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+      query = Yuriita::Query.new(inputs: [active_input])
+
+      formatter = Yuriita::QueryFormatter.new(param_key: :q)
+      parameters = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+        formatter: formatter,
+      )
+      result = parameters.select(hidden_input)
+
+      expect(result).to eq({ q: "is:hidden" })
+    end
+  end
+
+  describe "#deselect" do
+    it "removes all existing inputs from the query" do
+      active_input = build(:input, qualifier: "is", term: "active")
+      active_filter = build(:expression_filter, input: active_input)
+      active_option = build(:option, name: "Active", filter: active_filter)
+      hidden_input = build(:input, qualifier: "is", term: "hidden")
+      hidden_filter = build(:expression_filter, input: hidden_input)
+      hidden_option = build(:option, name: "Hidden", filter: hidden_filter)
+      query = Yuriita::Query.new(inputs: [active_input, hidden_input])
+
+      formatter = Yuriita::QueryFormatter.new(param_key: :q)
+      parameters = described_class.new(
+        options: [active_option, hidden_option],
+        query: query,
+        formatter: formatter,
+      )
+      result = parameters.deselect(hidden_input)
+
+      expect(result).to eq({ q: "" })
+    end
+  end
+end


### PR DESCRIPTION
When a user selects or deselects an option we navigate to a new URL to
apply or un-apply that option. This requires that we be able to generate
the new parameters for the query based on the behavior of the collection
of options.

There are two behaviors for options, Single and Multi. Multi parameters
either add or remove the option in question from the params. Single
parameters replace all existing inputs in the collection with the option
in question on selection, or remove itself on de-selection.

This commit extracts these behaviors from the Collection objects into
their own classes. The collection objects are very slim now and in a
future commit could likely be removed and have their logic moved into
the Definition classes.