### PR TITLE
Extract selector from SearchCollection

### DIFF
--- a/lib/yuriita/all_or_explicit_select.rb
+++ b/lib/yuriita/all_or_explicit_select.rb
@@ -1,0 +1,34 @@
+module Yuriita
+  class AllOrExplicitSelect
+    def initialize(options:, query:)
+      @options = options
+      @query = query
+    end
+
+    def filters
+      active_options.map(&:filter)
+    end
+
+    def empty?
+      keywords.empty?
+    end
+
+    private
+
+    attr_reader :options, :query
+
+    def active_options
+      explicit_options.presence || options
+    end
+
+    def explicit_options
+      options.select do |option|
+        query.include?(option.input)
+      end
+    end
+
+    def keywords
+      query.keywords
+    end
+  end
+end

--- a/lib/yuriita/search_collection.rb
+++ b/lib/yuriita/search_collection.rb
@@ -6,11 +6,10 @@ module Yuriita
     end
 
     def apply(relation)
-      return relation if active_filters.empty? || keywords.empty?
+      selector = AllOrExplicitSelect.new(options: options, query: query)
+      return relation if selector.empty?
 
-      relations = active_filters.map do |filter|
-        filter.apply(relation, keywords)
-      end
+      relations = selector.filters.map { |filter| filter.apply(relation, keywords) }
 
       scope.combination.new(
         base_relation: relation,
@@ -21,20 +20,6 @@ module Yuriita
     private
 
     attr_reader :scope, :query
-
-    def active_filters
-      selected_options.map(&:filter)
-    end
-
-    def selected_options
-      explicit_options.presence || options
-    end
-
-    def explicit_options
-      options.select do |option|
-        query.include?(option.input)
-      end
-    end
 
     def options
       scope.options

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -86,6 +86,17 @@ FactoryBot.define do
     initialize_with { new(input: input, &block) }
   end
 
+  factory :search_filter, class: "Yuriita::SearchFilter" do
+    skip_create
+
+    input
+    combination { Yuriita::AndCombination }
+
+    block { ->(relation) { relation } }
+
+    initialize_with { new(input: input, combination: combination, &block) }
+  end
+
   factory :genre do
     tmdb_id
     name { "Comedy" }

--- a/spec/yuriita/all_or_explicit_select_spec.rb
+++ b/spec/yuriita/all_or_explicit_select_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Yuriita::AllOrExplicitSelect do
+  describe "filters" do
+    context "when there are no selected options" do
+      it "returns the all option's filters" do
+        title_input = build(:input, qualifier: "in", term: "title")
+        title_filter = build(:search_filter, input: title_input)
+        title_option = build(:option, name: "Title", filter: title_filter)
+        tagline_input = build(:input, qualifier: "in", term: "tagline")
+        tagline_filter = build(:search_filter, input: tagline_input)
+        tagline_option = build(:option, name: "Tagline", filter: tagline_filter)
+
+        query = build(:query, inputs: [])
+
+        selector = described_class.new(
+          options: [title_option, tagline_option],
+          query: query,
+        )
+
+        expect(selector.filters).to eq [title_filter, tagline_filter]
+      end
+    end
+
+    context "when there is a selected option" do
+      it "returns the selected options filters" do
+        title_input = build(:input, qualifier: "in", term: "title")
+        title_filter = build(:search_filter, input: title_input)
+        title_option = build(:option, name: "Title", filter: title_filter)
+        tagline_input = build(:input, qualifier: "in", term: "tagline")
+        tagline_filter = build(:search_filter, input: tagline_input)
+        tagline_option = build(:option, name: "Tagline", filter: tagline_filter)
+        note_input = build(:input, qualifier: "in", term: "note")
+        note_filter = build(:search_filter, input: note_input)
+        note_option = build(:option, name: "note", filter: note_filter)
+
+        query = build(
+          :query,
+          inputs: [
+            build(:input, qualifier: "in", term: "title"),
+            build(:input, qualifier: "in", term: "note"),
+          ],
+        )
+
+        selector = described_class.new(
+          options: [title_option, tagline_option, note_option],
+          query: query,
+        )
+
+        expect(selector.filters).to eq [title_filter, note_filter]
+      end
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true when there are no keywords" do
+      title_option = build_option("Title", "in", "title")
+      tagline_option = build_option("Tagline", "in", "tagline")
+      query = build(
+        :query,
+        inputs: [build(:input, qualifier: "in", term: "title")],
+      )
+
+      selector = described_class.new(
+        options: [title_option, tagline_option],
+        query: query,
+      )
+
+      expect(selector).to be_empty
+    end
+
+    it "returns false if there are any keywords" do
+      title_option = build_option("Title", "in", "title")
+      tagline_option = build_option("Tagline", "in", "tagline")
+      query = build(
+        :query,
+        inputs: ["cats"],
+      )
+
+      selector = described_class.new(
+        options: [title_option, tagline_option],
+        query: query,
+      )
+
+      expect(selector).not_to be_empty
+    end
+  end
+
+  def build_option(name, qualifier, term)
+    input = build(:input, qualifier: qualifier, term: term)
+    build(:option, name: name, filter: build(:search_filter, input: input))
+  end
+end


### PR DESCRIPTION
Similar to eeb5a8ea this extracts a selector for the search collection's
selection behavior. This selector uses all options if there are none
explicitly selected. If any are explicitly present all of them are used.