### PR TITLE
Quote terms with spaces when formatting query

### DIFF
--- a/lib/yuriita/query/input.rb
+++ b/lib/yuriita/query/input.rb
@@ -16,7 +16,11 @@ module Yuriita
       alias_method :eql?, :==
 
       def to_s
-        "#{qualifier}:#{term}"
+        if term.match?(" ")
+          "#{qualifier}:\"#{term}\""
+        else
+          "#{qualifier}:#{term}"
+        end
       end
     end
   end

--- a/spec/yuriita/query_formatter_spec.rb
+++ b/spec/yuriita/query_formatter_spec.rb
@@ -16,5 +16,14 @@ RSpec.describe Yuriita::QueryFormatter do
 
       expect(formatted).to eq({ q: "" })
     end
+
+    it "wraps the term in quotes when the query contains terms with spaces" do
+      string = "cats in:title is:\"post production\""
+      query = Yuriita::QueryBuilder.build(string)
+
+      formatted = described_class.new(param_key: :q).format(query)
+
+      expect(formatted).to eq({ q: string })
+    end
   end
 end


### PR DESCRIPTION
Previously, given an input like:
` input = Input.new(qualifier: "is", term: "post production")`
calling `#to_s` returned `is: post production`.
This fixes the formatter so that terms with spaces are returned in
quotes. Now, with the above input, calling `#to_s` returns:
`is: \"post production\"`