### PR TITLE
Fix bug that caused overly verbose queries

### DIFF
--- a/lib/yuriita/executor.rb
+++ b/lib/yuriita/executor.rb
@@ -5,18 +5,8 @@ module Yuriita
     end
 
     def run(relation)
-      clauses.reduce(relation) do |chain, scope|
-        # To execute, we need:
-        # - The relation
-        # - For each collection we need:
-        #   - The combination
-        #   - The list of selected filters for the combination
-        #   - (Maybe) the matching inputs for each filter.
-        #     This is the confusing part, because what if multiple inputs match?
-        #     Do we call the filter once per matching input?
-        # What do we call this thing? This could be what the assembler returns.
-        # It would allow us to find a common interface for the exector maybe?
-        scope.apply(chain)
+      clauses.reduce(relation) do |chain, clause|
+        chain.merge(clause.apply(relation))
       end
     end
 


### PR DESCRIPTION
The executor takes a list of Clauses and the base relation and produces
the final query. There was a subtle bug that caused the executor to
produce rather inefficient queries. These queries were actually correct,
but contained duplicate conditions that got worse the more clauses there
were.

Each clause takes a base relation and runs the filters on it. For
example, the base relation may be `Post.all` and the clause may hold a
filter that only returns published posts by calling
`relation.where(published: true)`. Previously, we were passing the
result of applying each filter to the next filter in the list. So given
our example, the next filter may filter by author and apply
`relation.where(author: 'eebs')`. The relation being passed to this
filter was the result of applying the published filter. This is all fine
if there is only a single filter in a clause. But because searching
combine multiple keywords and some definitions allow for multi-select,
some clauses may have multiple filters that must be combined.

If the base relation included a condition, and a clause combined
multiple filters using an OR, we may end up with the following, overly
verbose, query:

```sql
SELECT "posts".* FROM "posts"
WHERE ("posts"."published" = TRUE AND "posts"."author" = 'eebs')
OR ("posts"."published" = TRUE AND "posts"."author" = 'sally')
```

This query is correct, but the `published: true` portion is duplicated
unnecessarily.

What we really would like is:

```sql
SELECT "posts".* FROM "posts"
WHERE "posts"."published" = TRUE
AND ("posts"."author" = 'eebs' OR "posts"."author" = 'sally')
```

We can achieve the second form by changing which relation the executor
passes to a clause for resolution. Previously it passed the ongoing,
built-up relation to each successive clause.

```ruby
clauses.reduce(base_relation) do |ongoing_chain, clause|
  clause.apply(ongoing_chain)
end
```

Instead, we can pass the original, base relation to each clause and
merge the result with the ongoing chain.

```ruby
clauses.reduce(base_relation) do |ongoing_chain, clause|
  ongoing_chain.merge(clause.apply(base_relation))
end
```

The executor now correctly applies each filter in isolation and then
merges the result.