### PR TITLE
Add means to check if table is filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ Or install it yourself as:
 - Searching
 - Dynamically creating options
 
+### Clearing all filters, searches, and sorts
+
+You may wish to add a means to clear the current filters, searches, and sorts to
+your UI. Yuri-ita does provide an explicit means to reset the filters, but it
+does allow you to query the table to determine if it is currently filtered or
+not.
+
+```ruby
+table = Yuriita::Table.new(param_key: :q, params: { q: "is:published" })
+table.filtered? #=> true
+
+table = Yuriita::Table.new(param_key: :q, params: { q: "" })
+table.filtered? #=> false
+```
+
+You may use this `.fitlered?` method to conditionally render a link to reload
+the page without any query parameters.
+
+```erb
+<% if table.filtered? %>
+  <%= link_to "Clear all", posts_path %>
+<% end %>
+```
+
+This will reload the page without the table's query parameter, effectively
+resetting the table. There is no explicit reset because we want to leave it up
+to you to decide what "resetting" means. Resetting for your application may be
+reloading the page with some other default parameters.
+
+
+```erb
+<% if table.filtered? %>
+  <%= link_to "Clear all", posts_path(list: "mine") %>
+<% end %>
+```
+
 ## Examples
 
 ## Contributing

--- a/lib/yuriita/table.rb
+++ b/lib/yuriita/table.rb
@@ -20,7 +20,7 @@ module Yuriita
       if input.present?
         input.strip + SPACE
       else
-        input
+        input.strip
       end
     end
 
@@ -33,12 +33,24 @@ module Yuriita
       Runner.new(relation: relation, configuration: configuration).run(query)
     end
 
+    def filtered?
+      user_input.present?
+    end
+
     private
 
     attr_reader :relation, :params, :configuration, :param_key
 
     def input
-      params[param_key] || EMPTY_STRING
+      user_input || default_input
+    end
+
+    def user_input
+      params[param_key].presence
+    end
+
+    def default_input
+      EMPTY_STRING
     end
 
     def query

--- a/spec/example_app/app/views/movies/index.html.erb
+++ b/spec/example_app/app/views/movies/index.html.erb
@@ -5,6 +5,10 @@
     <%= form_tag movies_path, method: :get do %>
       <%= text_field_tag :q, table.q, size: 50, autocomplete: "off" %>
     <% end %>
+
+    <% if table.filtered? %>
+      <%= link_to "Clear current search, filters, and sort", movies_path %>
+    <% end %>
   </div>
 
   <div class="index-table">

--- a/spec/features/movies_spec.rb
+++ b/spec/features/movies_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe "user views the movies page" do
     expect(page).not_to have_content("The Prestige")
     expect(page).not_to have_content("Pretty Woman")
   end
+
+  scenario "clears active filters and searches" do
+    fight_club = create(:movie, :released, title: "Fight Club")
+    the_prestige = create(:movie, :rumored, title: "The Prestige")
+    pretty_woman = create(:movie, :cancelled, title: "Pretty Woman")
+
+    visit movies_path
+    click_link "Released"
+    click_link "Clear current search, filters, and sort"
+
+    expect(page).to have_content("Fight Club")
+    expect(page).to have_content("The Prestige")
+    expect(page).to have_content("Pretty Woman")
+  end
 end

--- a/spec/yuriita/table_spec.rb
+++ b/spec/yuriita/table_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Yuriita::Table do
+  describe "#filtered?" do
+    it "is true when user input is a non-empty string" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: { q: "is:pubished" },
+        param_key: :q,
+      )
+
+      expect(table.filtered?).to be true
+    end
+
+    it "is false when user input is an empty string" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: { q: "" },
+        param_key: :q,
+      )
+
+      expect(table.filtered?).to be false
+    end
+
+    it "is false with no user input" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: {},
+        param_key: :q,
+      )
+
+      expect(table.filtered?).to be false
+    end
+  end
+end


### PR DESCRIPTION
We would like to allow users to "reset" their table to some default
state. Instead of providing an explicit means to reset, we instead
provide a way to check if the table is currently filtered. By doing so
we can leave what it means to reset the table to the developer or
designer.