### PR TITLE
Include Enumerable in Configuration

### DIFF
--- a/lib/yuriita/assembler.rb
+++ b/lib/yuriita/assembler.rb
@@ -7,7 +7,7 @@ module Yuriita
     end
 
     def build(query)
-      configuration.definitions.each_value.map do |definition|
+      configuration.map do |definition|
         definition.apply(query: query)
       end
     end

--- a/lib/yuriita/configuration.rb
+++ b/lib/yuriita/configuration.rb
@@ -1,6 +1,6 @@
 module Yuriita
   class Configuration
-    attr_reader :definitions
+    include Enumerable
 
     def initialize(definitions)
       @definitions = definitions
@@ -9,5 +9,19 @@ module Yuriita
     def find_definition(key)
       definitions.fetch(key)
     end
+
+    def each(&block)
+      block or return enum_for(__method__) { size }
+      definitions.each_value(&block)
+      self
+    end
+
+    def size
+      definitions.size
+    end
+
+    private
+
+    attr_reader :definitions
   end
 end

--- a/spec/yuriita/configuration_spec.rb
+++ b/spec/yuriita/configuration_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Yuriita::Configuration do
+  describe "#each" do
+    it "yields each definition" do
+      published = double(:definition)
+      sort = double(:definition)
+
+      config = described_class.new({ published: published, sort: sort })
+
+      expect do |b|
+        config.each(&b)
+      end.to yield_successive_args(published, sort)
+    end
+  end
+
+  describe "#find_definition" do
+    it "returns a definition by key" do
+      definition = double(:definition)
+
+      config = described_class.new({ foo: definition })
+
+      expect(config.find_definition(:foo)).to eq definition
+    end
+
+    it "raises an exception when the key does not exist" do
+      config = described_class.new({})
+
+      expect { config.find_definition(:foo) }.to raise_exception(
+        KeyError,
+        "key not found: :foo",
+      )
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of definitions" do
+      definitions = {
+        published: double(:definition),
+        sort: double(:definition),
+      }
+      config = described_class.new(definitions)
+
+      expect(config.size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
The Configuration object is simply a fancy hash. Including Enumerable
makes it a little easier to work with.

This commit also adds some specs for the Configuration class.