### PR TITLE
Allow setting a default query input for a table

### DIFF
--- a/spec/yuriita/table_spec.rb
+++ b/spec/yuriita/table_spec.rb
@@ -1,22 +1,57 @@
 RSpec.describe Yuriita::Table do
-  describe "#filtered?" do
-    it "is true when user input is a non-empty string" do
+  describe "#q" do
+    it "returns the default input if none is given" do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration),
-        params: { q: "is:pubished" },
-        param_key: :q,
+        params: {},
+        default_input: "is:published"
+      )
+
+      expect(table.q).to eq "is:published "
+    end
+
+    it "returns the input when one is provided" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: { q: "" },
+        default_input: "is:published"
+      )
+
+      expect(table.q).to eq ""
+    end
+  end
+
+  describe "#filtered?" do
+    it "is true when user input is not equal to the default input" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: { q: "is:draft" },
+        default_input: "is:published",
       )
 
       expect(table.filtered?).to be true
     end
 
-    it "is false when user input is an empty string" do
+    it "is true when the user input is in a different order from the default" do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration),
-        params: { q: "" },
-        param_key: :q,
+        params: { q: "is:draft author:eebs" },
+        default_input: "author:eebs is:draft",
+      )
+
+      expect(table.filtered?).to be true
+    end
+
+    it "is false when user input is equal to the default input" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration),
+        params: { q: "is:published" },
+        default_input: "is:published",
       )
 
       expect(table.filtered?).to be false
@@ -27,7 +62,7 @@ RSpec.describe Yuriita::Table do
         relation: double(:relation),
         configuration: double(:configuration),
         params: {},
-        param_key: :q,
+        default_input: "is:released",
       )
 
       expect(table.filtered?).to be false


### PR DESCRIPTION
The Exclusive definition is a collection of mutually exclusive options.
One option is always selected, it is not possible to deselect all
options. This provides a basic means to provide a default option for a
collection of options.

But what if we want to provide a default for a Single select definition?
What if we want to provide a default option but allow the user to
deselect it if they so choose?

This brings us to needing to specify a default query string for a table.
Currently that default is an empty string, i.e., an empty query. This
means that when a user visits a table page with no query param, the
query is set to an empty string. For exclusive definitions the default
option is selected, while for other definitions no options are selected.

The developer or designer may wish to have some options pre-selected
when the user visits the page. An example may be a page with a list of
Movies. When initially visiting the page with no query param, we may
wish to display only movies whose status is "released". The released
option may be part of a Multi definition that allows the user to select
amongst "rumored", "released", and "cancelled".

One naive option would be to update all links to the movies page to
include the query parameter:

```erb
<%= link_to "Movies List, movies_path(q: "is:released") %>
```

This would require the developer to update all links to include the
query parameter. Changing the default would require changes in all links
to the movie page. This approach however does not address the case where
a user manually removes the query parameters from the URL.

A more robust solution is to provide the table with a default input
string. That's what this commit does. When defining a table a
`default_input` may be provided. This value will be used if the query
parameter is not present in the table's params.

```ruby
table = Yuriita::Table.new(
  relation: Post.all,
  params: params,
  configuration: PostConfiguration.build,
  default_input: "is:published",
)
```

A future improvement may be to move this to a table's Configuration
object. I don't imagine a scenario where we'd re-use a single
configuration with different default inputs, so it likely makes sense to
move this into the configuration object.