### PR TITLE
Alias #q method to param_key when provided

### DIFF
--- a/lib/yuriita/table.rb
+++ b/lib/yuriita/table.rb
@@ -19,6 +19,8 @@ module Yuriita
       @params = params
       @configuration = configuration
       @param_key = param_key
+
+      alias :"#{param_key}" :q
     end
 
     def q

--- a/spec/yuriita/table_spec.rb
+++ b/spec/yuriita/table_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Yuriita::Table do
 
       expect(table.q).to eq ""
     end
+
+    it "is aliased to the param key when provided" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration, default_input: "is:published"),
+        param_key: :input_query,
+        params: {input_query: ""},
+      )
+
+      expect(table.input_query).to eq ""
+    end
   end
 
   describe "#filtered?" do


### PR DESCRIPTION
This allows a user to call `table.x` when the `param_key` has been defined as `x` to get the input query.