### PR TITLE
(Demo) Add filter toggle component for multi-select

### DIFF
--- a/spec/example_app/app/assets/stylesheets/components/_filter-toggle.scss
+++ b/spec/example_app/app/assets/stylesheets/components/_filter-toggle.scss
@@ -1,0 +1,22 @@
+.filter-toggle {
+  border: 1px solid $gray-400;
+  border-radius: 5em;
+  display: inline-block;
+  margin-bottom: $spacing-xs;
+  padding: $spacing-xs $spacing-md;
+
+  &:hover {
+    border-color: $action-color;
+  }
+
+  &.active {
+    background-color: $action-color;
+    border-color: $action-color;
+    color: $white;
+
+    &:hover {
+      background-color: lighten($action-color, 8%);
+      border-color: lighten($action-color, 8%);
+    }
+  }
+}

--- a/spec/example_app/app/views/movies/index.html.erb
+++ b/spec/example_app/app/views/movies/index.html.erb
@@ -11,11 +11,21 @@
 <div class="site-body">
   <div class="site-body__content">
     <div class="filter-list">
-      <h2 class="filter-list__heading">Filter</h2>
-      <%= render "options", options: table.options_for(:status) %>
-      <%= render "options", options: table.options_for(:adult) %>
       <h2 class="filter-list__heading">Sort</h2>
       <%= render "options", options: table.options_for(:sort) %>
+
+      <h2 class="filter-list__heading">Status</h2>
+      <div>
+        <% table.options_for(:status).each do |option| %>
+          <% classes = option.selected? ? ["filter-toggle", "active"] : ["filter-toggle"] %>
+          <%= link_to movies_path(option.params), class: classes do %>
+            <span><%= option.name %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+      <h2 class="filter-list__heading">Rating</h2>
+      <%= render "options", options: table.options_for(:adult) %>
     </div>
 
     <div class="movie-list">

--- a/spec/features/view_options/multiple_spec.rb
+++ b/spec/features/view_options/multiple_spec.rb
@@ -59,6 +59,6 @@ RSpec.describe "multiple select options" do
   end
 
   def have_selected_option(text)
-    have_selector(".filter-list__link.active", text: text)
+    have_selector(".filter-toggle.active", text: text)
   end
 end


### PR DESCRIPTION
This creates a toggle link which is ideal for multi-select categories
that have several (but not too many) options. In The demo, this is
useful for filter categories such as Genre and Rating.

<img width="181" alt="image" src="https://user-images.githubusercontent.com/3891632/81425577-d9ac8100-9125-11ea-8e49-6ceb353b7c87.png">
