### PR TITLE
Add Yuriita::Search to allow custom param_keys

### DIFF
--- a/lib/yuriita/search.rb
+++ b/lib/yuriita/search.rb
@@ -1,0 +1,13 @@
+require "active_model"
+
+module Yuriita
+  class Search
+    include ActiveModel::Model
+
+    def initialize(table, param_key)
+      define_singleton_method(param_key) do
+        table.q
+      end
+    end
+  end
+end

--- a/lib/yuriita/table.rb
+++ b/lib/yuriita/table.rb
@@ -19,7 +19,10 @@ module Yuriita
       @params = params
       @configuration = configuration
       @param_key = param_key
+      @search = Yuriita::Search.new(self, @param_key)
     end
+
+    attr_reader :search
 
     def q
       output =

--- a/spec/example_app/app/controllers/movies_controller.rb
+++ b/spec/example_app/app/controllers/movies_controller.rb
@@ -11,10 +11,11 @@ class MoviesController < ApplicationController
       relation: Movie.all,
       params: table_params,
       configuration: MovieDefinition.build,
+      param_key: :query
     )
   end
 
   def table_params
-    params.permit(:q)
+    params.permit(:query)
   end
 end

--- a/spec/example_app/app/views/movies/index.html.erb
+++ b/spec/example_app/app/views/movies/index.html.erb
@@ -2,9 +2,8 @@
   <div class="site-header__content">
     <h1>Top Movies</h1>
 
-    <%= form_tag movies_path, method: :get, class: "index-search" do %>
-      <%= label_tag :q, "Search" %>
-      <%= text_field_tag :q, table.q, size: 50, autocomplete: "off" %>
+    <%= form_for table.search, url: movies_path, method: :get, class: "index-search" do |form| %>
+      <%= form.text_field :query, size: 50, autocomplete: "off" %>
     <% end %>
   </div>
 </div>

--- a/spec/features/movies_spec.rb
+++ b/spec/features/movies_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "user views the movies page" do
     the_prestige = create(:movie, :rumored, title: "The Prestige")
     pretty_woman = create(:movie, :cancelled, title: "Pretty Woman")
 
-    visit movies_path(q: "is:released")
+    visit movies_path(query: "is:released")
 
     expect(page).to have_content("Fight Club")
     expect(page).not_to have_content("The Prestige")

--- a/spec/yuriita/table_spec.rb
+++ b/spec/yuriita/table_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe Yuriita::Table do
     end
   end
 
+  describe "#search" do
+    it "returns the input with the given param_key" do
+      table = described_class.new(
+        relation: double(:relation),
+        configuration: double(:configuration, default_input: "is:published"),
+        param_key: :query,
+        params: {query: "is:published"},
+      )
+
+      expect(table.search.query).to eq "is:published "
+    end
+  end
+
   describe "#filtered?" do
     it "is true when user input is not equal to the default input" do
       table = described_class.new(


### PR DESCRIPTION
This allows a user to define any param_key value and then call
table.search.x, where x is the param_key, in order to retrieve the input
string. The search object was necessary in order to avoid conflicts if
the user defines param_key to be the name of a method that already
exists on Yuriita::Table.