### PR TITLE
Add Clauses::Identity

### DIFF
--- a/lib/yuriita/clauses/filter.rb
+++ b/lib/yuriita/clauses/filter.rb
@@ -7,8 +7,6 @@ module Yuriita
       end
 
       def apply(relation)
-        return relation if unselected?
-
         relations = filters.map { |filter| filter.apply(relation) }
         combination.new(base_relation: relation, relations: relations).combine
       end
@@ -16,10 +14,6 @@ module Yuriita
       private
 
       attr_reader :filters, :combination
-
-      def unselected?
-        filters.empty?
-      end
     end
   end
 end

--- a/lib/yuriita/clauses/identity.rb
+++ b/lib/yuriita/clauses/identity.rb
@@ -1,0 +1,9 @@
+module Yuriita
+  module Clauses
+    class Identity
+      def apply(relation)
+        relation
+      end
+    end
+  end
+end

--- a/lib/yuriita/clauses/search.rb
+++ b/lib/yuriita/clauses/search.rb
@@ -8,8 +8,6 @@ module Yuriita
       end
 
       def apply(relation)
-        return relation if unselected?
-
         relations = filters.map { |filter| filter.apply(relation, keywords) }
         combination.new(base_relation: relation, relations: relations).combine
       end
@@ -17,10 +15,6 @@ module Yuriita
       private
 
       attr_reader :filters, :keywords, :combination
-
-      def unselected?
-        filters.empty? || keywords.empty?
-      end
     end
   end
 end

--- a/lib/yuriita/definitions/exclusive.rb
+++ b/lib/yuriita/definitions/exclusive.rb
@@ -9,14 +9,9 @@ module Yuriita
       end
 
       def apply(query:)
-        selector = Selects::Exclusive.new(
-          options: options,
-          default: default,
-          query: query,
-        )
+        filter = selected_filter(query)
 
-        filters = [selector.filter]
-        Clauses::Filter.new(filters: filters, combination: combination)
+        Clauses::Filter.new(filters: [filter], combination: combination)
       end
 
       def view_options(query:, param_key:)
@@ -29,6 +24,14 @@ module Yuriita
 
       def combination
         AndCombination
+      end
+
+      def selected_filter(query)
+        Selects::Exclusive.new(
+          options: options,
+          default: default,
+          query: query,
+        ).filter
       end
     end
   end

--- a/lib/yuriita/definitions/multiple.rb
+++ b/lib/yuriita/definitions/multiple.rb
@@ -9,9 +9,13 @@ module Yuriita
       end
 
       def apply(query:)
-        selector = Selects::Multiple.new(options: options, query: query)
+        filters = selected_filters(query)
 
-        Clauses::Filter.new(filters: selector.filters, combination: combination)
+        if filters.present?
+          Clauses::Filter.new(filters: filters, combination: combination)
+        else
+          Clauses::Identity.new
+        end
       end
 
       def view_options(query:, param_key:)
@@ -20,6 +24,12 @@ module Yuriita
           query: query,
           formatter: Yuriita::QueryFormatter.new(param_key: param_key),
         ).view_options
+      end
+
+      private
+
+      def selected_filters(query)
+        Selects::Multiple.new(options: options, query: query).filters
       end
     end
   end

--- a/lib/yuriita/definitions/scope.rb
+++ b/lib/yuriita/definitions/scope.rb
@@ -9,13 +9,24 @@ module Yuriita
       end
 
       def apply(query:)
-        selector = Selects::AllOrExplicit.new(options: options, query: query)
+        filters = selected_filters(query)
+        keywords = query.keywords
 
-        Clauses::Search.new(
-          filters: selector.filters,
-          keywords: query.keywords,
-          combination: combination,
-        )
+        if keywords.present?
+          Clauses::Search.new(
+            filters: filters,
+            keywords: keywords,
+            combination: combination,
+          )
+        else
+          Clauses::Identity.new
+        end
+      end
+
+      private
+
+      def selected_filters(query)
+        Selects::AllOrExplicit.new(options: options, query: query).filters
       end
     end
   end

--- a/lib/yuriita/definitions/single.rb
+++ b/lib/yuriita/definitions/single.rb
@@ -8,10 +8,13 @@ module Yuriita
       end
 
       def apply(query:)
-        selector = Selects::Single.new(options: options, query: query)
+        filter = selected_filter(query)
 
-        filters = [selector.filter].compact
-        Clauses::Filter.new(filters: filters, combination: combination)
+        if filter.present?
+          Clauses::Filter.new(filters: [filter], combination: combination)
+        else
+          Clauses::Identity.new
+        end
       end
 
       def view_options(query:, param_key:)
@@ -24,6 +27,10 @@ module Yuriita
 
       def combination
         AndCombination
+      end
+
+      def selected_filter(query)
+        Selects::Single.new(options: options, query: query).filter
       end
     end
   end

--- a/spec/yuriita/clauses/filter_spec.rb
+++ b/spec/yuriita/clauses/filter_spec.rb
@@ -2,17 +2,6 @@ require "rails_helper"
 
 RSpec.describe Yuriita::Clauses::Filter do
   describe "#apply" do
-    it "returns the relation when there are no filters" do
-      filters = []
-      combination = Yuriita::AndCombination
-      relation = double(:relation)
-
-      clause = described_class.new(filters: filters, combination: combination)
-      result = clause.apply(relation)
-
-      expect(result).to eq(relation)
-    end
-
     it "combines the applied filters using the combination" do
       published = create(:post, :published)
       draft = create(:post, :draft)

--- a/spec/yuriita/clauses/identity_spec.rb
+++ b/spec/yuriita/clauses/identity_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Yuriita::Clauses::Identity do
+  describe "#apply" do
+    it "returns the given relation with no changes" do
+      relation = double(:relation)
+
+      clause = described_class.new
+      result = clause.apply(relation)
+
+      expect(result).to eq(relation)
+    end
+  end
+end

--- a/spec/yuriita/clauses/search_spec.rb
+++ b/spec/yuriita/clauses/search_spec.rb
@@ -2,20 +2,6 @@ require "rails_helper"
 
 RSpec.describe Yuriita::Clauses::Search do
   describe "#apply" do
-    it "returns the relation when there are no filters or keywords" do
-      combination = Yuriita::OrCombination
-      relation = double(:relation)
-
-      clause = described_class.new(
-        filters: [],
-        keywords: [],
-        combination: combination,
-      )
-      result = clause.apply(relation)
-
-      expect(result).to eq(relation)
-    end
-
     it "combines the applied filters using the combination" do
       cats_post = create(:post, title: "cats")
       ducks_post = create(:post, title: "ducks", description: "cats")


### PR DESCRIPTION
As part of execution, all Definitions are given the Query and need to
provide a Clause object back. This Clause is applied to the initial
Relation. This Clause object updates the relation to change the database
query. When a Definition does not match the Query, it still must return
a Clause.

Previously, we would return a Filter or Search clause. These clauses
would check their internal state, and if no filters or keywords were
present they would return the relation unchanged.

This commit introduces an Identity clause that can be returned from the
definition when it does not match the query. This allows the Filter and
Search clauses assume they will only be used when they actually have
something to do.