### PR TITLE
Wrap `class` in `html` hash in `form_for`

### DIFF
--- a/spec/example_app/app/views/movies/index.html.erb
+++ b/spec/example_app/app/views/movies/index.html.erb
@@ -2,7 +2,7 @@
   <div class="site-header__content">
     <h1>Top Movies</h1>
 
-    <%= form_for table.search, url: movies_path, method: :get, class: "index-search" do |form| %>
+    <%= form_for table.search, url: movies_path, method: :get, html: { class: "index-search" } do |form| %>
       <%= form.text_field :query, size: 50, autocomplete: "off" %>
     <% end %>
   </div>


### PR DESCRIPTION
The form wasn't getting the class `index-search` because it wasn't nested in an `html` hash.