### PR TITLE
Add dynamic filtering

### DIFF
--- a/lib/yuriita/clauses/dynamic.rb
+++ b/lib/yuriita/clauses/dynamic.rb
@@ -1,0 +1,18 @@
+module Yuriita
+  module Clauses
+    class Dynamic
+      def initialize(filter:, input:)
+        @filter = filter
+        @input = input
+      end
+
+      def apply(relation)
+        filter.apply(relation, input)
+      end
+
+      private
+
+      attr_reader :filter, :input
+    end
+  end
+end

--- a/lib/yuriita/definitions/dynamic.rb
+++ b/lib/yuriita/definitions/dynamic.rb
@@ -1,0 +1,38 @@
+module Yuriita
+  module Definitions
+    class Dynamic
+      def initialize(filter:)
+        @filter = filter
+      end
+
+      def apply(query:)
+        input = select_input(query)
+
+        if input.present?
+          Clauses::Dynamic.new(filter: filter, input: input)
+        else
+          Clauses::Identity.new
+        end
+      end
+
+      private
+
+      attr_reader :filter
+
+      def select_input(query)
+        matching_inputs(query).last
+      end
+
+      def matching_inputs(query)
+        query.select do |input|
+          case input
+          when Inputs::Expression
+            input.qualifier == filter.qualifier
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yuriita/dynamic_filter.rb
+++ b/lib/yuriita/dynamic_filter.rb
@@ -1,0 +1,18 @@
+module Yuriita
+  class DynamicFilter
+    attr_reader :qualifier
+
+    def initialize(qualifier:, &block)
+      @qualifier = qualifier
+      @block = block
+    end
+
+    def apply(relation, input)
+      block.call(relation, input)
+    end
+
+    private
+
+    attr_reader :block
+  end
+end

--- a/spec/example_app/app/models/post.rb
+++ b/spec/example_app/app/models/post.rb
@@ -8,6 +8,10 @@ class Post < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :draft, -> { where(published: false) }
 
+  def self.authored_by(username)
+    joins(:author).where(users: {username: username})
+  end
+
   def self.search(field, term)
     sanitized_value = sanitize_sql_like(term)
     where("#{field} ILIKE :term", term: "%#{sanitized_value}%")

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -15,6 +15,7 @@ class PostDefinition
       category: category_definition,
       sort: sort_definition,
       post: post_scope,
+      author: author_definition,
     }
   end
 
@@ -142,5 +143,13 @@ class PostDefinition
     end
 
     Yuriita::Option.new(name: "Title Asc", filter: filter)
+  end
+
+  def author_definition
+    filter = Yuriita::DynamicFilter.new(qualifier: "author") do |relation, input|
+      relation.authored_by(input.term)
+    end
+
+    Yuriita::Definitions::Dynamic.new(filter: filter)
   end
 end

--- a/spec/integration/filtering/dynamic_spec.rb
+++ b/spec/integration/filtering/dynamic_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "dynamic filtering" do
+  it "returns results matching the input term" do
+    eebs = create(:author, username: "eebs")
+    sally = create(:author, username: "sally")
+    eebs_post = create(:post, author: eebs)
+    sally_post = create(:post, author: sally)
+
+    result = Yuriita.filter(
+      Post.all,
+      "author:eebs",
+      PostDefinition.build,
+    )
+
+    expect(result.relation).to contain_exactly(eebs_post)
+  end
+
+  it "returns results matching the last input" do
+    eebs = create(:author, username: "eebs")
+    sally = create(:author, username: "sally")
+    eebs_post = create(:post, author: eebs)
+    sally_post = create(:post, author: sally)
+
+    result = Yuriita.filter(
+      Post.all,
+      "author:eebs author:sally",
+      PostDefinition.build,
+    )
+
+    expect(result.relation).to contain_exactly(sally_post)
+  end
+end


### PR DESCRIPTION
This allows the usage of an input's term in the query itself. Given the
query string

```
author:eebs
```

we can create a filter that is passed the input object, allowing the DB
query to use the term `eebs` in the query itself.