### PR TITLE
Use `form_with` for search input so params are sent correctly

### DIFF
--- a/spec/example_app/app/views/movies/index.html.erb
+++ b/spec/example_app/app/views/movies/index.html.erb
@@ -2,8 +2,9 @@
   <div class="site-header__content">
     <h1>Top Movies</h1>
 
-    <%= form_for table.search, url: movies_path, method: :get, html: { class: "index-search" } do |form| %>
-      <%= form.text_field :query, size: 50, autocomplete: "off" %>
+    <%= form_with url: movies_path, method: :get, local: true, html: { class: "index-search" } do |form| %>
+      <%= form.label :query, "Search" %>
+      <%= form.text_field :query, size: 50, autocomplete: "off", value: table.search.query %>
     <% end %>
   </div>
 </div>

--- a/spec/system/movies_spec.rb
+++ b/spec/system/movies_spec.rb
@@ -38,4 +38,16 @@ RSpec.describe "user views the movies page" do
     expect(page).to have_content("The Prestige")
     expect(page).to have_content("Pretty Woman")
   end
+
+  scenario "searches for a keyword", js: true do
+    fight_club = create(:movie, :released, title: "Fight Club")
+    the_prestige = create(:movie, :rumored, title: "The Prestige")
+
+    visit movies_path
+    fill_in "Search", with: "Fight in:title"
+    find("#query").send_keys(:enter)
+
+    expect(page).to have_content("Fight Club")
+    expect(page).not_to have_content("The Prestige")
+  end
 end


### PR DESCRIPTION
When we added the Search object to the Table, it broke the search input
in the demo application. When using
`form_for(table.search)`
it changes the parameters that are submitted to the server to
`{"yuriita_search"=>{"query"=>"king"}}`

This uses `form_with` instead of `form_for` so that the input params are
not wrapped in the model name.