### PR TITLE
Add documentation generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "rails"
 
 gem "bootsnap", ">= 1.4.4", require: false
 gem "bourbon"
+gem "commonmarker"
+gem "github-markup", require: "github/markup"
 gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 4.3"
 gem "sass-rails", ">= 6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.2)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.3)
@@ -104,6 +106,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     filigree (0.4.1)
+    github-markup (1.7.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     http-accept (1.7.0)
@@ -211,6 +214,8 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    ruby-enum (0.8.0)
+      i18n
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -275,8 +280,10 @@ DEPENDENCIES
   bundler (~> 1.17)
   byebug
   capybara (>= 3.26)
+  commonmarker
   dotenv-rails
   factory_bot_rails
+  github-markup
   listen (>= 3.0.5, < 3.3)
   pg (>= 0.18, < 2.0)
   pry-rails

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ library.][demo]
 
 [demo]: https://yuriita-prerelease.herokuapp.com/movies
 
-## Introduction
+## What is Yuri-ita?
 
 Yuri-ita offers a powerful set of tools to build powerful user interfaces that
 allow users to find exactly what they need while allowing designers and

--- a/spec/example_app/app/assets/stylesheets/documentation.scss
+++ b/spec/example_app/app/assets/stylesheets/documentation.scss
@@ -1,0 +1,66 @@
+@import "base/variables";
+
+@import url('https://fonts.googleapis.com/css?family=Roboto|Fira+Code:300,400,500');
+
+$code-black: #202020;
+$code-white: #e0e0dc;
+$code-green: #b0bf82;
+$code-blue: #8fbdcc;
+$code-yellow: #f8d29d;
+$code-red: #b95c56;
+$code-orange: #e36209;
+
+
+body {
+  color: #566b78;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  line-height: 1.5;
+  margin: 0 auto;
+  max-width: 50em;
+  padding: 4em 1em;
+}
+
+h2 {
+  margin-top: $spacing-md;
+  margin-bottom: $spacing-sm;
+  padding-bottom: .3em;
+  border-bottom: 1px solid #eaecef;
+}
+
+code,
+pre {
+  background: #f0f0f8;
+}
+
+pre code {
+  display: inline-block;
+}
+
+code {
+  font-family: "Fira Code";
+  font-variant-ligatures: none;
+  padding: 2px 4px;
+
+  &.hljs {
+    .hljs-string { color: $code-green; }
+    .hljs-subst { color: $code-white; }
+    .hljs-constant { color: $code-blue; }
+    .hljs-symbol { color: $code-red; }
+    .hljs-keyword { color: $code-red; }
+
+    .hljs-title,
+    .hljs-parent { color: $code-blue; }
+
+    .hljs-tag { color: $code-yellow; }
+  }
+
+}
+
+pre {
+  padding: 1em;
+  border-left: 2px solid #6931e0;
+}
+
+a {
+  color: #e03131;
+}

--- a/spec/example_app/app/controllers/documentation_controller.rb
+++ b/spec/example_app/app/controllers/documentation_controller.rb
@@ -1,0 +1,31 @@
+class DocumentationController < ApplicationController
+  def index
+    render_documentation_page "README"
+  end
+
+  private
+
+  def render_documentation_page(name)
+    path = full_page_path(name)
+
+    if File.exist?(path)
+      html = parse_document(path)
+      render layout: "documentation", html: html.html_safe
+    else
+      render_not_found
+    end
+  end
+
+  def full_page_path(page)
+    Rails.root + "../../#{page}.md"
+  end
+
+  def parse_document(path)
+    file = path.to_s
+    GitHub::Markup.render(file, File.read(file))
+  end
+
+  def render_not_found
+    raise ActionController::RoutingError, 'Not Found'
+  end
+end

--- a/spec/example_app/app/controllers/landings_controller.rb
+++ b/spec/example_app/app/controllers/landings_controller.rb
@@ -1,4 +1,0 @@
-class LandingsController < ApplicationController
-  def index
-  end
-end

--- a/spec/example_app/app/javascript/controllers/syntax_highlight_controller.js
+++ b/spec/example_app/app/javascript/controllers/syntax_highlight_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+import hljs from 'highlight.js/lib/core';
+import ruby from 'highlight.js/lib/languages/ruby';
+
+hljs.registerLanguage('ruby', ruby);
+
+export default class extends Controller {
+  connect() {
+    document.querySelectorAll('pre code').forEach((block) => {
+      hljs.highlightBlock(block);
+    });
+  }
+}

--- a/spec/example_app/app/views/layouts/documentation.html.erb
+++ b/spec/example_app/app/views/layouts/documentation.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Yuri-ita Documentation</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag 'documentation', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
+  </head>
+
+  <body data-controller="syntax-highlight">
+    <%= yield %>
+  </body>
+</html>

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: "landings#index"
+  root to: "documentation#index"
 
   resources :movies, only: :index
 end

--- a/spec/example_app/package.json
+++ b/spec/example_app/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@rails/ujs": "^6.0.2-2",
     "@rails/webpacker": "5.1.1",
+    "highlight.js": "^10.0.3",
     "stimulus": "^1.1.1"
   },
   "devDependencies": {

--- a/spec/example_app/yarn.lock
+++ b/spec/example_app/yarn.lock
@@ -3299,6 +3299,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.0.3.tgz#5effcc58420f113f279a0badb8ac50c4be06e63b"
+  integrity sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"

--- a/spec/system/documentation_spec.rb
+++ b/spec/system/documentation_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "viewing documentation" do
+  it "shows the readme on the root page" do
+    visit root_path
+
+    expect(page).to have_content "What is Yuri-ita?"
+    expect(page).to have_content "Installation"
+  end
+end
+

--- a/spec/system/landing_spec.rb
+++ b/spec/system/landing_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "user views the landing page" do
-  it "shows some general information" do
-    visit root_path
-
-    expect(page).to have_content "Yuri-ita"
-  end
-end


### PR DESCRIPTION
We'd like to be able to display documentation on the demo site.

This commit adds basic rendering of the Readme with some basic styles
and syntax highlighting. In the future we can add sub pages with
additional content.