### PR TITLE
Words can contain any character.

### DIFF
--- a/lib/yuriita/lexer.rb
+++ b/lib/yuriita/lexer.rb
@@ -6,7 +6,7 @@ module Yuriita
     rule(/:/) { :COLON }
     rule(/in/) { :IN }
     rule(/sort/) { :SORT }
-    rule(/[a-zA-Z_-]+/) { |t| [:WORD, t] }
+    rule(/[^ \t\f:"]+/) { |t| [:WORD, t] }
     rule(/"/) { :QUOTE }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require "yuriita"
 
 require "support/tokens"
+require "support/matchers/produce_tokens"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe Yuriita::Lexer do
       )
     end
 
+    it "recognizes words with non-alpha characters" do
+      expect("email:user.name123@example.com").to produce_tokens(
+        [
+          "WORD(email)",
+          "COLON",
+          "WORD(user.name123@example.com)",
+          "EOS",
+        ]
+      )
+    end
+
     it "recognizes quoted words" do
       expect("\"quoted words\"").to produce_tokens(
         [

--- a/spec/yuriita/query_builder_spec.rb
+++ b/spec/yuriita/query_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Yuriita do
       relation = double(:relation)
       definition = double(:definition)
 
-      result = Yuriita.filter(relation, "invalid[", definition)
+      result = Yuriita.filter(relation, "invalid::", definition)
 
       expect(result).not_to be_successful
     end
@@ -28,7 +28,7 @@ RSpec.describe Yuriita do
     end
 
     it "raises a ParseError when the input is invalid" do
-      expect { Yuriita.build_query("inavlid[") }.to raise_error(
+      expect { Yuriita.build_query("inavlid::") }.to raise_error(
         Yuriita::ParseError
       )
     end

--- a/spec/yuriita_spec.rb
+++ b/spec/yuriita_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Yuriita do
       relation = double(:relation)
       definition = double(:definition)
 
-      result = Yuriita.filter(relation, "invalid[", definition)
+      result = Yuriita.filter(relation, "invalid::", definition)
 
       expect(result).not_to be_successful
     end
@@ -32,7 +32,7 @@ RSpec.describe Yuriita do
     end
 
     it "raises a ParseError when the input is invalid" do
-      expect { Yuriita.build_query("inavlid[") }.to raise_error(
+      expect { Yuriita.build_query("inavlid::") }.to raise_error(
         Yuriita::ParseError
       )
     end


### PR DESCRIPTION
This commit expands the lexer's definition of a word to include any
character that doesn't already have some other special meaning within the
grammar (i.e. whitespace, `:` and `"`).

This allows Yuri-ita to be used for a greater variety of situations, for
example filtering by users' email address or by customers' order numbers.