### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Or install it yourself as:
     $ gem install yuri-ita
 
 For instructions on how to integrate Yuri-ita with your Rails application,
-[view the Getting Started documentation](docs/getting_started).
+[view the Getting Started documentation](docs/getting_started.md).
 
 ## Contributing
 


### PR DESCRIPTION
Fix the broken link to the getting started docs. 

(This project looks really promising and I can't wait for it to mature, we have a hand rolled version of something similar and this looks much nicer.) 