### PR TITLE
Remove special casing for sort and scope inputs

### DIFF
--- a/lib/yuriita/inputs/scope.rb
+++ b/lib/yuriita/inputs/scope.rb
@@ -1,9 +1,0 @@
-module Yuriita
-  module Inputs
-    Scope = Struct.new(:qualifier, :term) do
-      def to_s
-        "#{qualifier}:#{term}"
-      end
-    end
-  end
-end

--- a/lib/yuriita/inputs/sort.rb
+++ b/lib/yuriita/inputs/sort.rb
@@ -1,9 +1,0 @@
-module Yuriita
-  module Inputs
-    Sort = Struct.new(:qualifier, :term) do
-      def to_s
-        "#{qualifier}:#{term}"
-      end
-    end
-  end
-end

--- a/lib/yuriita/lexer.rb
+++ b/lib/yuriita/lexer.rb
@@ -4,8 +4,6 @@ module Yuriita
   class Lexer < RLTK::Lexer
     rule(/[ \t\f]+/) { :SPACE }
     rule(/:/) { :COLON }
-    rule(/in/) { :IN }
-    rule(/sort/) { :SORT }
     rule(/[^ \t\f:"]+/) { |t| [:WORD, t] }
     rule(/"/) { :QUOTE }
   end

--- a/lib/yuriita/parser.rb
+++ b/lib/yuriita/parser.rb
@@ -18,9 +18,7 @@ module Yuriita
 
     production(:input) do
       clause(".keyword") { |keyword| keyword }
-      clause(".scope") { |scope| scope }
       clause(".expression") { |expression| expression }
-      clause(".sort") { |sort| sort }
     end
 
     production(:keyword) do
@@ -33,18 +31,6 @@ module Yuriita
     production(:expression) do
       clause(".qualifier COLON .term") do |qualifier, term|
         Inputs::Expression.new(qualifier, term)
-      end
-    end
-
-    production(:scope) do
-      clause("IN COLON .scope_field") do |scope|
-        Inputs::Scope.new("in", scope)
-      end
-    end
-
-    production(:sort) do
-      clause("SORT COLON .order") do |order|
-        Inputs::Sort.new("sort", order)
       end
     end
 

--- a/spec/example_app/app/models/movie_definition.rb
+++ b/spec/example_app/app/models/movie_definition.rb
@@ -31,7 +31,7 @@ class MovieDefinition
 
   def title_option
     filter = Yuriita::SearchFilter.new(
-      input: Yuriita::Inputs::Scope.new("in", "title"),
+      input: Yuriita::Inputs::Expression.new("in", "title"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:title, term)
@@ -42,7 +42,7 @@ class MovieDefinition
 
   def tagline_option
     filter = Yuriita::SearchFilter.new(
-      input: Yuriita::Inputs::Scope.new("in", "tagline"),
+      input: Yuriita::Inputs::Expression.new("in", "tagline"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:tagline, term)
@@ -144,7 +144,7 @@ class MovieDefinition
 
   def rating_sort_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Sort.new("sort", "default"),
+      input: Yuriita::Inputs::Expression.new("sort", "default"),
     ) do |relation|
       relation.order(vote_average: :desc)
     end
@@ -154,7 +154,7 @@ class MovieDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Sort.new("sort", "title-desc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-desc"),
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -164,7 +164,7 @@ class MovieDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Sort.new("sort", "title-asc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-asc"),
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -32,7 +32,7 @@ class PostDefinition
 
   def title_option
     filter = Yuriita::SearchFilter.new(
-      input: Yuriita::Inputs::Scope.new("in", "title"),
+      input: Yuriita::Inputs::Expression.new("in", "title"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:title, term)
@@ -43,7 +43,7 @@ class PostDefinition
 
   def body_option
     filter = Yuriita::SearchFilter.new(
-      input: Yuriita::Inputs::Scope.new("in", "body"),
+      input: Yuriita::Inputs::Expression.new("in", "body"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:body, term)
@@ -54,7 +54,7 @@ class PostDefinition
 
   def description_option
     filter = Yuriita::SearchFilter.new(
-      input: Yuriita::Inputs::Scope.new("in", "description"),
+      input: Yuriita::Inputs::Expression.new("in", "description"),
       combination: Yuriita::AndCombination,
     ) do |relation, term|
       relation.search(:description, term)
@@ -127,7 +127,7 @@ class PostDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Sort.new("sort", "title-desc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-desc"),
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -137,7 +137,7 @@ class PostDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Sort.new("sort", "title-asc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-asc"),
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -73,24 +73,6 @@ FactoryBot.define do
     initialize_with { new(qualifier, term) }
   end
 
-  factory :scope, class: "Yuriita::Inputs::Scope" do
-    skip_create
-
-    qualifier { "in" }
-    term { "title" }
-
-    initialize_with { new(qualifier, term) }
-  end
-
-  factory :sort, class: "Yuriita::Inputs::Sort" do
-    skip_create
-
-    qualifier { "sort" }
-    term { "created-asc" }
-
-    initialize_with { new(qualifier, term) }
-  end
-
   factory :keyword, class: "Yuriita::Inputs::Keyword" do
     skip_create
 
@@ -120,7 +102,7 @@ FactoryBot.define do
   factory :search_filter, class: "Yuriita::SearchFilter" do
     skip_create
 
-    input { build(:scope) }
+    input { build(:expression, qualifier: "in") }
     combination { Yuriita::AndCombination }
 
     block { ->(relation, term) { relation } }

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Yuriita::Lexer do
     it "recognizes words with hyphens" do
       expect("sort:created-desc").to produce_tokens(
         [
-          "SORT",
+          "WORD(sort)",
           "COLON",
           "WORD(created-desc)",
           "EOS",
@@ -63,50 +63,6 @@ RSpec.describe Yuriita::Lexer do
           "SPACE",
           "WORD(words)",
           "QUOTE",
-          "EOS",
-        ]
-      )
-    end
-
-    it "recognizes 'in'" do
-      expect("in:body").to produce_tokens(
-        [
-          "IN",
-          "COLON",
-          "WORD(body)",
-          "EOS",
-        ]
-      )
-    end
-
-    it "does not recognize 'in' within other words" do
-      expect("interrupt:gum").to produce_tokens(
-        [
-          "WORD(interrupt)",
-          "COLON",
-          "WORD(gum)",
-          "EOS",
-        ]
-      )
-    end
-
-    it "recognizes 'sort'" do
-      expect("sort:body").to produce_tokens(
-        [
-          "SORT",
-          "COLON",
-          "WORD(body)",
-          "EOS",
-        ]
-      )
-    end
-
-    it "does not recognize 'sort' within other words" do
-      expect("sorta:gum").to produce_tokens(
-        [
-          "WORD(sorta)",
-          "COLON",
-          "WORD(gum)",
           "EOS",
         ]
       )

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -158,44 +158,6 @@ RSpec.describe Yuriita::Parser do
         expression("author", "eebs"),
       )
     end
-
-    it "parses a sort input" do
-      query = parse(tokens(
-        [:SORT], [:COLON], [:WORD, "title"], [:EOS],
-      ))
-      expect(query.inputs).to contain_exactly(
-        sort("sort", "title")
-      )
-    end
-
-    it "parses a scope input" do
-      query = parse(tokens(
-        [:IN], [:COLON], [:WORD, "title"], [:EOS],
-      ))
-
-      expect(query.inputs).to contain_exactly(
-        scope("in", "title")
-      )
-    end
-
-    it "parses a scope_input with keywords" do
-      query = parse(tokens(
-        [:WORD, "awesome"],
-        [:SPACE],
-        [:IN],
-        [:COLON],
-        [:WORD, "title"],
-        [:SPACE],
-        [:WORD, "ideas"],
-        [:EOS],
-      ))
-
-      expect(query.inputs).to contain_exactly(
-        scope("in", "title"),
-        keyword("awesome"),
-        keyword("ideas"),
-      )
-    end
   end
 
   def parse(tokens)
@@ -208,13 +170,5 @@ RSpec.describe Yuriita::Parser do
 
   def keyword(value)
     Yuriita::Inputs::Keyword.new(value)
-  end
-
-  def sort(qualifier, term)
-    Yuriita::Inputs::Sort.new(qualifier, term)
-  end
-
-  def scope(qualifier, term)
-    Yuriita::Inputs::Scope.new(qualifier, term)
   end
 end

--- a/spec/yuriita/selects/all_or_explicit_spec.rb
+++ b/spec/yuriita/selects/all_or_explicit_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
   describe "filters" do
     context "when there are no selected options" do
       it "returns the all option's filters" do
-        title_input = build(:scope, qualifier: "in", term: "title")
+        title_input = build(:expression, qualifier: "in", term: "title")
         title_filter = build(:search_filter, input: title_input)
         title_option = build(:option, name: "Title", filter: title_filter)
-        tagline_input = build(:scope, qualifier: "in", term: "tagline")
+        tagline_input = build(:expression, qualifier: "in", term: "tagline")
         tagline_filter = build(:search_filter, input: tagline_input)
         tagline_option = build(:option, name: "Tagline", filter: tagline_filter)
 
@@ -22,21 +22,21 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
 
     context "when there is a selected option" do
       it "returns the selected options filters" do
-        title_input = build(:scope, qualifier: "in", term: "title")
+        title_input = build(:expression, qualifier: "in", term: "title")
         title_filter = build(:search_filter, input: title_input)
         title_option = build(:option, name: "Title", filter: title_filter)
-        tagline_input = build(:scope, qualifier: "in", term: "tagline")
+        tagline_input = build(:expression, qualifier: "in", term: "tagline")
         tagline_filter = build(:search_filter, input: tagline_input)
         tagline_option = build(:option, name: "Tagline", filter: tagline_filter)
-        note_input = build(:scope, qualifier: "in", term: "note")
+        note_input = build(:expression, qualifier: "in", term: "note")
         note_filter = build(:search_filter, input: note_input)
         note_option = build(:option, name: "note", filter: note_filter)
 
         query = build(
           :query,
           inputs: [
-            build(:scope, qualifier: "in", term: "title"),
-            build(:scope, qualifier: "in", term: "note"),
+            build(:expression, qualifier: "in", term: "title"),
+            build(:expression, qualifier: "in", term: "note"),
           ],
         )
 
@@ -51,7 +51,7 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
   end
 
   def build_option(name, qualifier, term)
-    input = build(:scope, qualifier: qualifier, term: term)
+    input = build(:expression, qualifier: qualifier, term: term)
     build(:option, name: name, filter: build(:search_filter, input: input))
   end
 end


### PR DESCRIPTION
There is no need to parse `in:title` and `sort:created-asc` as special
inputs. These can be expressed as Expression inputs as they follow the
`qualifier:term` pattern. They were overly restrictive in that you could
not use `as:author` to define a scope to search keywords. For example,
it may be desirable to create a configuration that caused

```
james as:author
```

to search for the keyword `james` as the author of a post. Previously,
you would be forced to use `in:author` which may not be as clear.

The same applies to sort inputs. You can now use `order:title` if you
wanted to.

*This change requires that all configuration options update any scope or
sort inputs to use the expression input*

```diff
- Yuriita::Inputs::Scope.new("in", "title")
+ Yuriita::Inputs::Expression.new("in", "title")
```

```diff
- Yuriita::Inputs::Sort.new("sort", "title-asc")
+ Yuriita::Inputs::Expression.new("sort", "title-asc")
```