### PR TITLE
Lex a constrained version of ISO8601 date and time

### DIFF
--- a/lib/yuriita/lexer.rb
+++ b/lib/yuriita/lexer.rb
@@ -2,9 +2,20 @@ require "rltk/lexer"
 
 module Yuriita
   class Lexer < RLTK::Lexer
+    DATETIME_REGEX = %r{
+      ([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])
+      (
+        T
+        ((2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))
+        (Z|[+-](2[0-3]|[01][0-9])(:[0-5][0-9])?)
+      )?
+    }x
+
     rule(/[ \t\f]+/) { :SPACE }
     rule(/:/) { :COLON }
-    rule(/[^ \t\f:"]+/) { |t| [:WORD, t] }
+    rule(/>/) { :GT }
+    rule(DATETIME_REGEX) { |d| [:DATETIME, DateTime.parse(d)] }
+    rule(/[^ >\t\f:"]+/) { |t| [:WORD, t] }
     rule(/"/) { :QUOTE }
   end
 end

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -67,5 +67,44 @@ RSpec.describe Yuriita::Lexer do
         ]
       )
     end
+
+    it "recognizes dates" do
+      input = "created:>2020-01-01"
+      expect(input).to produce_tokens(
+        [
+          "WORD(created)",
+          "COLON",
+          "GT",
+          "DATETIME(2020-01-01T00:00:00+00:00)",
+          "EOS",
+        ]
+      )
+    end
+
+    it "recognizes dates with a time and timezone offset" do
+      input = "created:>2020-01-01T15:30:00+03:00"
+      expect(input).to produce_tokens(
+        [
+          "WORD(created)",
+          "COLON",
+          "GT",
+          "DATETIME(2020-01-01T15:30:00+03:00)",
+          "EOS",
+        ]
+      )
+    end
+
+    it "recognizes dates with a time and UTC offset" do
+      input = "created:>2020-01-01T15:30:00Z"
+      expect(input).to produce_tokens(
+        [
+          "WORD(created)",
+          "COLON",
+          "GT",
+          "DATETIME(2020-01-01T15:30:00+00:00)",
+          "EOS",
+        ]
+      )
+    end
   end
 end


### PR DESCRIPTION
I'd like to be able to support filters that can compare dates. Date
inputs would come in two forms. The first form would be a comparative
form, with a single date and a comparison operator.

```
created:>2020-01-01
```

The second form would be a range with and start and end date.

```
created:2020-01-01..2020-06-01
```

This commit begins that work by allowing the lexer to parse dates. These
dates do not accept the full ISO8601 spec, but a reasonable subset.

Dates can be in the following forms

```
YYYY-MM-DD => 2020-01-01
YYYY-MM-DDTHH:MM:SS+00:00 => 2020-01-01T14:20:00+05:00
YYYY-MM-DDTHH:MM:SS+00 => 2020-01-01T14:20:00+05
YYYY-MM-DDTHH:MM:SSZ => 2020-01-01T14:20:00+00:00
```

One issue I ran into was with the ordering of the rules and how I had
written them. I noticed that the input `created:>2020-01-01` was
producing the tokens

```
WORD(created)
COLON
WORD(>2020-01-01)
EOS
```

The [RLTK documentation] mentions that by default lexer will select the
longest substring matching any rule. The other option is to select the
first substring that matches a rule. If I did not add `>` to the list of
characters excluded from a `WORD`, the `WORD` rule would pick up the `>`
and the date.

It appears I have two options. I can use the default behavior and add
`>` (and other operators) to the excluded characters from the `WORD`
rule, or I can switch to the `match_first` behavior. I'm not entirely
sure which one to use or what the trade offs are.

I could imagine that if I wanted to allow operators inside a `WORD` I
would have to switch to `match_first` or keep track of state while
lexing. I would likely have to push a state where it would be possible
to match a word and then pop that state off we know a word shouldn't be
matched next. Or maybe the inverse of that?

For now it seems easy enough to disallow operators from words. The
downside is that you couldn't search for something like `"key => value"`
as a keyword. Maybe this is acceptable?

[RLTK documentation]: https://github.com/chriswailes/RLTK#first-and-longest-match