### PR TITLE
Remove rubygems-server-gems-graphql-pro gem registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  rubygems-server-gems-graphql-pro:
-    type: rubygems-server
-    url: https://gems.graphql.pro
-    username: "${{secrets.RUBYGEMS_SERVER_GEMS_GRAPHQL_PRO_USERNAME}}"
-    password: "${{secrets.RUBYGEMS_SERVER_GEMS_GRAPHQL_PRO_PASSWORD}}"
 
 updates:
 - package-ecosystem: bundler


### PR DESCRIPTION
The missing username and password for this registry is preventing dependabot from creating PRs. We don't have a graphql-pro account, so this is not needed.