### PR TITLE
Replace commonmarker with Redcarpet::Markdown

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,11 @@ gem "rails"
 
 gem "bootsnap", ">= 1.4.4", require: false
 gem "bourbon"
-gem "commonmarker", "< 1.0"
 gem "github-markup", require: "github/markup"
 gem "jsbundling-rails"
 gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 6.0"
+gem "redcarpet"
 gem "sass-rails", ">= 6"
 gem "sentry-raven"
 gem "themoviedb-api"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    commonmarker (0.23.10)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -234,6 +233,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
@@ -332,7 +332,6 @@ DEPENDENCIES
   bundler (~> 2.3)
   byebug
   capybara (>= 3.26)
-  commonmarker (< 1.0)
   dotenv-rails
   factory_bot_rails
   github-markup
@@ -343,6 +342,7 @@ DEPENDENCIES
   puma (~> 6.0)
   rails
   rake (~> 13.0)
+  redcarpet
   rspec (~> 3.0)
   rspec-rails
   rspec_junit_formatter (~> 0.4)


### PR DESCRIPTION
**This PR:**
- Replaces [commonmarker](https://github.com/gjtorikian/commonmarker) with [redcarpet](https://github.com/vmg/redcarpet)
- Simplifies the output of `rspec` to only show failures and not display the details of every test

Dependabot wants to upgrade `commonmarker` to a [version after 1.0](https://github.com/thoughtbot/yuri-ita/pull/336) but the latest version doesn't work because of [this issue](https://github.com/github/markup/issues/1758).

Redcarpet renders the example app documentation correctly without any additional code changes.