### PR TITLE
Remove sentry-raven gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 6.4"
 gem "redcarpet"
 gem "sass-rails", ">= 6"
-gem "sentry-raven"
 gem "themoviedb-api"
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,11 +121,6 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
-      logger
-    faraday-net_http (3.1.1)
-      net-http
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     filigree (0.4.1)
@@ -164,8 +159,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
-    net-http (0.4.1)
-      uri
     net-imap (0.5.0)
       date
       net-protocol
@@ -290,8 +283,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -307,7 +298,6 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uri (0.13.0)
     useragent (0.16.10)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -349,7 +339,6 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4)
   sass-rails (>= 6)
   selenium-webdriver
-  sentry-raven
   themoviedb-api
   web-console (>= 3.3.0)
   yuri-ita!

--- a/spec/example_app/config/initializers/sentry-raven.rb
+++ b/spec/example_app/config/initializers/sentry-raven.rb
@@ -1,3 +1,0 @@
-Raven.configure do |config|
-  config.dsn = ENV.fetch("SENTRY_DSN", "")
-end


### PR DESCRIPTION
**This PR:**
- Removes the `sentry-raven` gem, which was replacted by [sentry-ruby](https://github.com/getsentry/sentry-ruby)

Sentry-raven blocks the ability to see errors while developing, but it’s also not necessary in production for the demo application.