### PR TITLE
Fix README rendering in DocumentationController

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "rails"
 
 gem "bootsnap", ">= 1.4.4", require: false
 gem "bourbon"
-gem "github-markup", require: "github/markup"
 gem "jsbundling-rails"
 gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     filigree (0.4.1)
-    github-markup (5.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     http-accept (1.7.0)
@@ -325,7 +324,6 @@ DEPENDENCIES
   capybara (>= 3.26)
   dotenv-rails
   factory_bot_rails
-  github-markup
   jsbundling-rails
   listen (>= 3.0.5)
   pg (>= 0.18, < 2.0)

--- a/spec/example_app/app/controllers/documentation_controller.rb
+++ b/spec/example_app/app/controllers/documentation_controller.rb
@@ -15,7 +15,7 @@ class DocumentationController < ApplicationController
     if File.exist?(path)
       html = File.read(path)
       renderer = Redcarpet::Render::HTML.new
-      markdown = Redcarpet::Markdown.new(renderer, extensions = {fenced_code_blocks: true})
+      markdown = Redcarpet::Markdown.new(renderer, {fenced_code_blocks: true})
       rendered_markdown = markdown.render(html)
 
       render layout: "documentation", html: rendered_markdown.html_safe

--- a/spec/example_app/app/controllers/documentation_controller.rb
+++ b/spec/example_app/app/controllers/documentation_controller.rb
@@ -13,8 +13,12 @@ class DocumentationController < ApplicationController
     path = full_page_path(name)
 
     if File.exist?(path)
-      html = parse_document(path)
-      render layout: "documentation", html: html.html_safe
+      html = File.read(path)
+      renderer = Redcarpet::Render::HTML.new
+      markdown = Redcarpet::Markdown.new(renderer, extensions = {fenced_code_blocks: true})
+      rendered_markdown = markdown.render(html)
+
+      render layout: "documentation", html: rendered_markdown.html_safe
     else
       render_not_found
     end
@@ -22,11 +26,6 @@ class DocumentationController < ApplicationController
 
   def full_page_path(page)
     Rails.root + "../../#{page}.md"
-  end
-
-  def parse_document(path)
-    file = path.to_s
-    GitHub::Markup.render(file, File.read(file))
   end
 
   def render_not_found


### PR DESCRIPTION
**This PR:**
- Fixes issues in the rendering of the `README` (e.g., some code blocks) when browsing to `localhost:300`
- Removes the [markup](https://github.com/github/markup) gem

**Screenshots**

**Fixed:**
<img src="https://github.com/user-attachments/assets/ebb55ca9-05e1-40a4-800b-fe2980d71a83" width="400">

**Issue with code block:**
<img src="https://github.com/user-attachments/assets/7ac8a9c2-ac0d-4a63-93a2-c6f471160896" width="400">
