### PR TITLE
Use Ruby function shorthand and apply standard linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can create static filters that always run the same query:
 ```ruby
 input = Yuriita::Inputs::Expression.new("is", "published")
 
-Yuriita::ExpressionFilter.new(input: input) do |relation|
+Yuriita::ExpressionFilter.new(input:) do |relation|
   relation.where(published: true)
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
-require File.expand_path('../spec/example_app/config/application', __FILE__)
+require File.expand_path("../spec/example_app/config/application", __FILE__)
 
 Bundler::GemHelper.install_tasks
-
 
 Rails.application.load_tasks
 
@@ -15,4 +14,4 @@ if defined? RSpec
   end
 end
 
-task :default => :spec
+task default: :spec

--- a/lib/yuriita/assembler.rb
+++ b/lib/yuriita/assembler.rb
@@ -8,7 +8,7 @@ module Yuriita
 
     def build(query)
       configuration.map do |definition|
-        definition.apply(query: query)
+        definition.apply(query:)
       end
     end
   end

--- a/lib/yuriita/clauses/filter.rb
+++ b/lib/yuriita/clauses/filter.rb
@@ -8,7 +8,7 @@ module Yuriita
 
       def apply(relation)
         relations = filters.map { |filter| filter.apply(relation) }
-        combination.new(base_relation: relation, relations: relations).combine
+        combination.new(base_relation: relation, relations:).combine
       end
 
       private

--- a/lib/yuriita/clauses/search.rb
+++ b/lib/yuriita/clauses/search.rb
@@ -9,7 +9,7 @@ module Yuriita
 
       def apply(relation)
         relations = filters.map { |filter| filter.apply(relation, keywords) }
-        combination.new(base_relation: relation, relations: relations).combine
+        combination.new(base_relation: relation, relations:).combine
       end
 
       private

--- a/lib/yuriita/collection.rb
+++ b/lib/yuriita/collection.rb
@@ -34,7 +34,7 @@ module Yuriita
     def process(action, *)
       action = action.to_s
 
-      unless method_name = find_method_name(action)
+      unless (method_name = find_method_name(action))
         raise ActionNotFound.new("The action '#{action}' could not be found for #{self.class.name}", self, action)
       end
 

--- a/lib/yuriita/collection.rb
+++ b/lib/yuriita/collection.rb
@@ -31,21 +31,20 @@ module Yuriita
 
     private
 
-    def process(action, *args)
+    def process(action, *)
       action = action.to_s
 
       unless method_name = find_method_name(action)
         raise ActionNotFound.new("The action '#{action}' could not be found for #{self.class.name}", self, action)
       end
 
-      process_action(method_name, *args)
+      process_action(method_name, *)
     end
 
-    def process_action(method_name, *args)
-      send_action(method_name, *args)
+    def process_action(method_name, *)
+      send_action(method_name, *)
     end
-    alias send_action send
-
+    alias_method :send_action, :send
 
     def find_method_name(action)
       if action_method?(action)

--- a/lib/yuriita/definitions/dynamic.rb
+++ b/lib/yuriita/definitions/dynamic.rb
@@ -9,7 +9,7 @@ module Yuriita
         input = select_input(query)
 
         if input.present?
-          Clauses::Dynamic.new(filter: filter, input: input)
+          Clauses::Dynamic.new(filter:, input:)
         else
           Clauses::Identity.new
         end

--- a/lib/yuriita/definitions/exclusive.rb
+++ b/lib/yuriita/definitions/exclusive.rb
@@ -24,7 +24,7 @@ module Yuriita
         Selects::Exclusive.new(
           options:,
           default:,
-          query:,
+          query:
         ).filter
       end
     end

--- a/lib/yuriita/definitions/exclusive.rb
+++ b/lib/yuriita/definitions/exclusive.rb
@@ -11,7 +11,7 @@ module Yuriita
       def apply(query:)
         filter = selected_filter(query)
 
-        Clauses::Filter.new(filters: [filter], combination: combination)
+        Clauses::Filter.new(filters: [filter], combination:)
       end
 
       private
@@ -22,9 +22,9 @@ module Yuriita
 
       def selected_filter(query)
         Selects::Exclusive.new(
-          options: options,
-          default: default,
-          query: query,
+          options:,
+          default:,
+          query:,
         ).filter
       end
     end

--- a/lib/yuriita/definitions/multiple.rb
+++ b/lib/yuriita/definitions/multiple.rb
@@ -12,7 +12,7 @@ module Yuriita
         filters = selected_filters(query)
 
         if filters.present?
-          Clauses::Filter.new(filters: filters, combination: combination)
+          Clauses::Filter.new(filters:, combination:)
         else
           Clauses::Identity.new
         end
@@ -21,7 +21,7 @@ module Yuriita
       private
 
       def selected_filters(query)
-        Selects::Multiple.new(options: options, query: query).filters
+        Selects::Multiple.new(options:, query:).filters
       end
     end
   end

--- a/lib/yuriita/definitions/scope.rb
+++ b/lib/yuriita/definitions/scope.rb
@@ -16,7 +16,7 @@ module Yuriita
           Clauses::Search.new(
             filters:,
             keywords:,
-            combination:,
+            combination:
           )
         else
           Clauses::Identity.new

--- a/lib/yuriita/definitions/scope.rb
+++ b/lib/yuriita/definitions/scope.rb
@@ -14,9 +14,9 @@ module Yuriita
 
         if keywords.present?
           Clauses::Search.new(
-            filters: filters,
-            keywords: keywords,
-            combination: combination,
+            filters:,
+            keywords:,
+            combination:,
           )
         else
           Clauses::Identity.new
@@ -26,7 +26,7 @@ module Yuriita
       private
 
       def selected_filters(query)
-        Selects::AllOrExplicit.new(options: options, query: query).filters
+        Selects::AllOrExplicit.new(options:, query:).filters
       end
     end
   end

--- a/lib/yuriita/definitions/single.rb
+++ b/lib/yuriita/definitions/single.rb
@@ -11,7 +11,7 @@ module Yuriita
         filter = selected_filter(query)
 
         if filter.present?
-          Clauses::Filter.new(filters: [filter], combination: combination)
+          Clauses::Filter.new(filters: [filter], combination:)
         else
           Clauses::Identity.new
         end
@@ -24,7 +24,7 @@ module Yuriita
       end
 
       def selected_filter(query)
-        Selects::Single.new(options: options, query: query).filter
+        Selects::Single.new(options:, query:).filter
       end
     end
   end

--- a/lib/yuriita/errors/collection/action_not_found.rb
+++ b/lib/yuriita/errors/collection/action_not_found.rb
@@ -8,7 +8,6 @@ module Yuriita
         @action = action
         super(message)
       end
-
     end
   end
 end

--- a/lib/yuriita/or_combination.rb
+++ b/lib/yuriita/or_combination.rb
@@ -20,4 +20,3 @@ module Yuriita
     end
   end
 end
-

--- a/lib/yuriita/query.rb
+++ b/lib/yuriita/query.rb
@@ -13,7 +13,7 @@ module Yuriita
     end
 
     def keywords
-      inputs.select{ |input| input.is_a?(Yuriita::Inputs::Keyword) }
+      inputs.select { |input| input.is_a?(Yuriita::Inputs::Keyword) }
     end
 
     def each(&block)
@@ -26,7 +26,7 @@ module Yuriita
       inputs << input
       self
     end
-    alias << add_input
+    alias_method :<<, :add_input
 
     def delete(input)
       inputs.delete(input)
@@ -42,7 +42,7 @@ module Yuriita
     def size
       inputs.size
     end
-    alias length size
+    alias_method :length, :size
 
     def initialize_dup(original)
       super

--- a/lib/yuriita/router.rb
+++ b/lib/yuriita/router.rb
@@ -9,7 +9,7 @@ module Yuriita
     end
 
     def route(input, relation)
-      if route = match_for(input)
+      if (route = match_for(input))
         collection = route.collection
         collection.dispatch(route.action, input, relation)
       end

--- a/lib/yuriita/search_filter.rb
+++ b/lib/yuriita/search_filter.rb
@@ -15,7 +15,7 @@ module Yuriita
 
       combination.new(
         base_relation: relation,
-        relations: relations,
+        relations: relations
       ).combine
     end
 

--- a/lib/yuriita/search_filter.rb
+++ b/lib/yuriita/search_filter.rb
@@ -15,7 +15,7 @@ module Yuriita
 
       combination.new(
         base_relation: relation,
-        relations: relations
+        relations:
       ).combine
     end
 

--- a/spec/example_app/Rakefile
+++ b/spec/example_app/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/spec/example_app/app/controllers/documentation_controller.rb
+++ b/spec/example_app/app/controllers/documentation_controller.rb
@@ -30,6 +30,6 @@ class DocumentationController < ApplicationController
   end
 
   def render_not_found
-    raise ActionController::RoutingError, 'Not Found'
+    raise ActionController::RoutingError, "Not Found"
   end
 end

--- a/spec/example_app/app/controllers/movies_controller.rb
+++ b/spec/example_app/app/controllers/movies_controller.rb
@@ -1,7 +1,7 @@
 class MoviesController < ApplicationController
   def index
     table = build_table
-    render locals: { table: table }
+    render locals: { table: }
   end
 
   private

--- a/spec/example_app/app/controllers/movies_controller.rb
+++ b/spec/example_app/app/controllers/movies_controller.rb
@@ -1,7 +1,7 @@
 class MoviesController < ApplicationController
   def index
     table = build_table
-    render locals: { table: }
+    render locals: {table:}
   end
 
   private

--- a/spec/example_app/app/models/genre_sync.rb
+++ b/spec/example_app/app/models/genre_sync.rb
@@ -1,6 +1,6 @@
 class GenreSync
   def self.run(client:)
-    new(client: client).run
+    new(client:).run
   end
 
   def initialize(client:)

--- a/spec/example_app/app/models/movie_definition.rb
+++ b/spec/example_app/app/models/movie_definition.rb
@@ -14,14 +14,14 @@ class MovieDefinition
       status: status_definition,
       adult: adult_definition,
       sort: sort_definition,
-      movie: movie_scope,
+      movie: movie_scope
     }
   end
 
   def movie_scope
     Yuriita::Definitions::Scope.new(
       options: search_options,
-      combination: Yuriita::OrCombination,
+      combination: Yuriita::OrCombination
     )
   end
 
@@ -32,7 +32,7 @@ class MovieDefinition
   def title_option
     filter = Yuriita::SearchFilter.new(
       input: Yuriita::Inputs::Expression.new("in", "title"),
-      combination: Yuriita::AndCombination,
+      combination: Yuriita::AndCombination
     ) do |relation, term|
       relation.search(:title, term)
     end
@@ -43,7 +43,7 @@ class MovieDefinition
   def tagline_option
     filter = Yuriita::SearchFilter.new(
       input: Yuriita::Inputs::Expression.new("in", "tagline"),
-      combination: Yuriita::AndCombination,
+      combination: Yuriita::AndCombination
     ) do |relation, term|
       relation.search(:tagline, term)
     end
@@ -54,7 +54,7 @@ class MovieDefinition
   def status_definition
     Yuriita::Definitions::Multiple.new(
       options: status_options,
-      combination: Yuriita::OrCombination,
+      combination: Yuriita::OrCombination
     )
   end
 
@@ -63,13 +63,13 @@ class MovieDefinition
       rumored_option,
       post_production_option,
       released_option,
-      cancelled_option,
+      cancelled_option
     ]
   end
 
   def rumored_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "rumored"),
+      input: Yuriita::Inputs::Expression.new("is", "rumored")
     ) do |relation|
       relation.rumored
     end
@@ -79,7 +79,7 @@ class MovieDefinition
 
   def released_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "released"),
+      input: Yuriita::Inputs::Expression.new("is", "released")
     ) do |relation|
       relation.released
     end
@@ -89,7 +89,7 @@ class MovieDefinition
 
   def post_production_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "post-production"),
+      input: Yuriita::Inputs::Expression.new("is", "post-production")
     ) do |relation|
       relation.post_production
     end
@@ -99,7 +99,7 @@ class MovieDefinition
 
   def cancelled_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "cancelled"),
+      input: Yuriita::Inputs::Expression.new("is", "cancelled")
     ) do |relation|
       relation.cancelled
     end
@@ -113,7 +113,7 @@ class MovieDefinition
 
   def adult_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "adult"),
+      input: Yuriita::Inputs::Expression.new("is", "adult")
     ) do |relation|
       relation.where(adult: true)
     end
@@ -123,7 +123,7 @@ class MovieDefinition
 
   def safe_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "safe"),
+      input: Yuriita::Inputs::Expression.new("is", "safe")
     ) do |relation|
       relation.where(adult: false)
     end
@@ -134,7 +134,7 @@ class MovieDefinition
   def sort_definition
     Yuriita::Definitions::Exclusive.new(
       options: sort_options,
-      default: rating_sort_option,
+      default: rating_sort_option
     )
   end
 
@@ -144,7 +144,7 @@ class MovieDefinition
 
   def rating_sort_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("sort", "default"),
+      input: Yuriita::Inputs::Expression.new("sort", "default")
     ) do |relation|
       relation.order(vote_average: :desc)
     end
@@ -154,7 +154,7 @@ class MovieDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("sort", "title-desc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-desc")
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -164,7 +164,7 @@ class MovieDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("sort", "title-asc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-asc")
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/example_app/app/models/movie_definition.rb
+++ b/spec/example_app/app/models/movie_definition.rb
@@ -37,7 +37,7 @@ class MovieDefinition
       relation.search(:title, term)
     end
 
-    Yuriita::Option.new(name: "In Title", filter: filter)
+    Yuriita::Option.new(name: "In Title", filter:)
   end
 
   def tagline_option
@@ -48,7 +48,7 @@ class MovieDefinition
       relation.search(:tagline, term)
     end
 
-    Yuriita::Option.new(name: "In Tagline", filter: filter)
+    Yuriita::Option.new(name: "In Tagline", filter:)
   end
 
   def status_definition
@@ -74,7 +74,7 @@ class MovieDefinition
       relation.rumored
     end
 
-    Yuriita::Option.new(name: "Rumored", filter: filter)
+    Yuriita::Option.new(name: "Rumored", filter:)
   end
 
   def released_option
@@ -84,7 +84,7 @@ class MovieDefinition
       relation.released
     end
 
-    Yuriita::Option.new(name: "Released", filter: filter)
+    Yuriita::Option.new(name: "Released", filter:)
   end
 
   def post_production_option
@@ -94,7 +94,7 @@ class MovieDefinition
       relation.post_production
     end
 
-    Yuriita::Option.new(name: "Post Production", filter: filter)
+    Yuriita::Option.new(name: "Post Production", filter:)
   end
 
   def cancelled_option
@@ -104,7 +104,7 @@ class MovieDefinition
       relation.cancelled
     end
 
-    Yuriita::Option.new(name: "Cancelled", filter: filter)
+    Yuriita::Option.new(name: "Cancelled", filter:)
   end
 
   def adult_definition
@@ -118,7 +118,7 @@ class MovieDefinition
       relation.where(adult: true)
     end
 
-    Yuriita::Option.new(name: "Adult", filter: filter)
+    Yuriita::Option.new(name: "Adult", filter:)
   end
 
   def safe_option
@@ -128,7 +128,7 @@ class MovieDefinition
       relation.where(adult: false)
     end
 
-    Yuriita::Option.new(name: "Safe", filter: filter)
+    Yuriita::Option.new(name: "Safe", filter:)
   end
 
   def sort_definition
@@ -149,7 +149,7 @@ class MovieDefinition
       relation.order(vote_average: :desc)
     end
 
-    Yuriita::Option.new(name: "Rating", filter: filter)
+    Yuriita::Option.new(name: "Rating", filter:)
   end
 
   def title_desc_option
@@ -159,7 +159,7 @@ class MovieDefinition
       relation.order(title: :desc)
     end
 
-    Yuriita::Option.new(name: "Title Desc", filter: filter)
+    Yuriita::Option.new(name: "Title Desc", filter:)
   end
 
   def title_asc_option
@@ -169,6 +169,6 @@ class MovieDefinition
       relation.order(title: :asc)
     end
 
-    Yuriita::Option.new(name: "Title Asc", filter: filter)
+    Yuriita::Option.new(name: "Title Asc", filter:)
   end
 end

--- a/spec/example_app/app/models/movie_sync.rb
+++ b/spec/example_app/app/models/movie_sync.rb
@@ -1,6 +1,6 @@
 class MovieSync
   def self.run(client:)
-    new(client: client).run
+    new(client:).run
   end
 
   def initialize(client:)

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -38,7 +38,7 @@ class PostDefinition
       relation.search(:title, term)
     end
 
-    Yuriita::Option.new(name: "In Title", filter: filter)
+    Yuriita::Option.new(name: "In Title", filter:)
   end
 
   def body_option
@@ -49,7 +49,7 @@ class PostDefinition
       relation.search(:body, term)
     end
 
-    Yuriita::Option.new(name: "In Body", filter: filter)
+    Yuriita::Option.new(name: "In Body", filter:)
   end
 
   def description_option
@@ -60,7 +60,7 @@ class PostDefinition
       relation.search(:description, term)
     end
 
-    Yuriita::Option.new(name: "In Description", filter: filter)
+    Yuriita::Option.new(name: "In Description", filter:)
   end
 
   def published_definition
@@ -81,7 +81,7 @@ class PostDefinition
       relation.published
     end
 
-    Yuriita::Option.new(name: "Published", filter: filter)
+    Yuriita::Option.new(name: "Published", filter:)
   end
 
   def draft_option
@@ -91,7 +91,7 @@ class PostDefinition
       relation.draft
     end
 
-    Yuriita::Option.new(name: "Draft", filter: filter)
+    Yuriita::Option.new(name: "Draft", filter:)
   end
 
   def category_definition
@@ -107,10 +107,10 @@ class PostDefinition
       filter = Yuriita::ExpressionFilter.new(
         input: Yuriita::Inputs::Expression.new("category", name),
       ) do |relation|
-        relation.joins(:categories).where(categories: { name: name })
+        relation.joins(:categories).where(categories: { name: })
       end
 
-      Yuriita::Option.new(name: name, filter: filter)
+      Yuriita::Option.new(name:, filter:)
     end
   end
 
@@ -132,7 +132,7 @@ class PostDefinition
       relation.order(title: :desc)
     end
 
-    Yuriita::Option.new(name: "Title Desc", filter: filter)
+    Yuriita::Option.new(name: "Title Desc", filter:)
   end
 
   def title_asc_option
@@ -142,7 +142,7 @@ class PostDefinition
       relation.order(title: :asc)
     end
 
-    Yuriita::Option.new(name: "Title Asc", filter: filter)
+    Yuriita::Option.new(name: "Title Asc", filter:)
   end
 
   def author_definition
@@ -150,6 +150,6 @@ class PostDefinition
       relation.authored_by(input.term)
     end
 
-    Yuriita::Definitions::Dynamic.new(filter: filter)
+    Yuriita::Definitions::Dynamic.new(filter:)
   end
 end

--- a/spec/example_app/app/models/post_definition.rb
+++ b/spec/example_app/app/models/post_definition.rb
@@ -15,14 +15,14 @@ class PostDefinition
       category: category_definition,
       sort: sort_definition,
       post: post_scope,
-      author: author_definition,
+      author: author_definition
     }
   end
 
   def post_scope
     Yuriita::Definitions::Scope.new(
       options: search_options,
-      combination: Yuriita::OrCombination,
+      combination: Yuriita::OrCombination
     )
   end
 
@@ -33,7 +33,7 @@ class PostDefinition
   def title_option
     filter = Yuriita::SearchFilter.new(
       input: Yuriita::Inputs::Expression.new("in", "title"),
-      combination: Yuriita::AndCombination,
+      combination: Yuriita::AndCombination
     ) do |relation, term|
       relation.search(:title, term)
     end
@@ -44,7 +44,7 @@ class PostDefinition
   def body_option
     filter = Yuriita::SearchFilter.new(
       input: Yuriita::Inputs::Expression.new("in", "body"),
-      combination: Yuriita::AndCombination,
+      combination: Yuriita::AndCombination
     ) do |relation, term|
       relation.search(:body, term)
     end
@@ -55,7 +55,7 @@ class PostDefinition
   def description_option
     filter = Yuriita::SearchFilter.new(
       input: Yuriita::Inputs::Expression.new("in", "description"),
-      combination: Yuriita::AndCombination,
+      combination: Yuriita::AndCombination
     ) do |relation, term|
       relation.search(:description, term)
     end
@@ -70,13 +70,13 @@ class PostDefinition
   def published_options
     [
       published_option,
-      draft_option,
+      draft_option
     ]
   end
 
   def published_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "published"),
+      input: Yuriita::Inputs::Expression.new("is", "published")
     ) do |relation|
       relation.published
     end
@@ -86,7 +86,7 @@ class PostDefinition
 
   def draft_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("is", "draft"),
+      input: Yuriita::Inputs::Expression.new("is", "draft")
     ) do |relation|
       relation.draft
     end
@@ -97,7 +97,7 @@ class PostDefinition
   def category_definition
     Yuriita::Definitions::Multiple.new(
       options: category_options,
-      combination: Yuriita::OrCombination,
+      combination: Yuriita::OrCombination
     )
   end
 
@@ -105,9 +105,9 @@ class PostDefinition
     Category.find_each.map do |category|
       name = category.name
       filter = Yuriita::ExpressionFilter.new(
-        input: Yuriita::Inputs::Expression.new("category", name),
+        input: Yuriita::Inputs::Expression.new("category", name)
       ) do |relation|
-        relation.joins(:categories).where(categories: { name: })
+        relation.joins(:categories).where(categories: {name:})
       end
 
       Yuriita::Option.new(name:, filter:)
@@ -117,7 +117,7 @@ class PostDefinition
   def sort_definition
     Yuriita::Definitions::Exclusive.new(
       options: sort_options,
-      default: title_desc_option,
+      default: title_desc_option
     )
   end
 
@@ -127,7 +127,7 @@ class PostDefinition
 
   def title_desc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("sort", "title-desc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-desc")
     ) do |relation|
       relation.order(title: :desc)
     end
@@ -137,7 +137,7 @@ class PostDefinition
 
   def title_asc_option
     filter = Yuriita::ExpressionFilter.new(
-      input: Yuriita::Inputs::Expression.new("sort", "title-asc"),
+      input: Yuriita::Inputs::Expression.new("sort", "title-asc")
     ) do |relation|
       relation.order(title: :asc)
     end

--- a/spec/example_app/app/models/tmdb_client.rb
+++ b/spec/example_app/app/models/tmdb_client.rb
@@ -21,7 +21,7 @@ class TmdbClient
         popularity: movie_data.popularity,
         release_date: movie_data.release_date,
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       }
     end
   end
@@ -32,7 +32,7 @@ class TmdbClient
         tmdb_id: genre.id,
         name: genre.name,
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       }
     end
   end
@@ -45,7 +45,7 @@ class TmdbClient
           movie_id: movie_id,
           genre_id: genre,
           created_at: Time.now,
-          updated_at: Time.now,
+          updated_at: Time.now
         }
       end
     end.flatten

--- a/spec/example_app/bin/setup
+++ b/spec/example_app/bin/setup
@@ -4,8 +4,8 @@ require "fileutils"
 APP_ROOT = File.expand_path("..", __dir__)
 APP_NAME = "example-app"
 
-def system!(*args)
-  system(*args, exception: true)
+def system!(*)
+  system(*, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do

--- a/spec/example_app/bin/yarn
+++ b/spec/example_app/bin/yarn
@@ -1,11 +1,9 @@
 #!/usr/bin/env ruby
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg", *ARGV
+rescue Errno::ENOENT
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/spec/example_app/config.ru
+++ b/spec/example_app/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/spec/example_app/config/environments/development.rb
+++ b/spec/example_app/config/environments/development.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
-    config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{2.days.to_i}" }
+    config.public_file_server.headers = {"Cache-Control" => "public, max-age=#{2.days.to_i}"}
   else
     config.action_controller.perform_caching = false
 

--- a/spec/example_app/config/environments/production.rb
+++ b/spec/example_app/config/environments/production.rb
@@ -48,11 +48,11 @@ Rails.application.configure do
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .tap { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/spec/example_app/config/environments/production.rb
+++ b/spec/example_app/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
     .tap { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.hour.to_i}" }
+  config.public_file_server.headers = {"Cache-Control" => "public, max-age=#{1.hour.to_i}"}
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true

--- a/spec/example_app/db/migrate/20200311125252_create_movies.rb
+++ b/spec/example_app/db/migrate/20200311125252_create_movies.rb
@@ -1,7 +1,7 @@
 class CreateMovies < ActiveRecord::Migration[6.0]
   def change
     create_table :movies do |t|
-      t.integer :tmdb_id, null: false, index: { unique: true }
+      t.integer :tmdb_id, null: false, index: {unique: true}
       t.string :title
       t.string :original_title
       t.string :tagline

--- a/spec/example_app/db/migrate/20200327150102_create_genres.rb
+++ b/spec/example_app/db/migrate/20200327150102_create_genres.rb
@@ -1,7 +1,7 @@
 class CreateGenres < ActiveRecord::Migration[6.0]
   def change
     create_table :genres do |t|
-      t.integer :tmdb_id, null: false, index: { unique: true }
+      t.integer :tmdb_id, null: false, index: {unique: true}
       t.string :name
 
       t.timestamps

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -2,5 +2,5 @@ Movie.destroy_all
 Genre.destroy_all
 client = TmdbClient.new
 
-GenreSync.run(client: client)
-MovieSync.run(client: client)
+GenreSync.run(client:)
+MovieSync.run(client:)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
     input { build(:expression) }
     block { ->(relation) { relation } }
 
-    initialize_with { new(input: input, &block) }
+    initialize_with { new(input:, &block) }
   end
 
   factory :search_filter, class: "Yuriita::SearchFilter" do
@@ -107,7 +107,7 @@ FactoryBot.define do
 
     block { ->(relation, term) { relation } }
 
-    initialize_with { new(input: input, combination: combination, &block) }
+    initialize_with { new(input:, combination:, &block) }
   end
 
   factory :genre do

--- a/spec/integration/combined_search_filter_sort_spec.rb
+++ b/spec/integration/combined_search_filter_sort_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "combining expressions, search, and sort" do
   it "returns keyword results, expression results, and sorted results" do
-    cat_post = create(:post, title: "Cats are great", published: false)
+    create(:post, title: "Cats are great", published: false)
     elephant_post = create(:post, title: "Elephants are great", published: true)
     duck_post = create(:post, title: "Ducks are great, too", published: true)
-    frog_post = create(:post, title: "Frogs are just ok", published: true)
+    create(:post, title: "Frogs are just ok", published: true)
 
     result = Yuriita.filter(
       Post.all,

--- a/spec/integration/empty_spec.rb
+++ b/spec/integration/empty_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "an empty input string" do
     result = Yuriita.filter(
       Post.all,
       "",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to match_array(Post.all)

--- a/spec/integration/filtering/by_expression_spec.rb
+++ b/spec/integration/filtering/by_expression_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe "filtering by expression" do
   it "returns results matching an expression" do
     published = create(:post, published: true)
-    not_published = create(:post, published: false)
+    create(:post, published: false)
 
     result = Yuriita.filter(
       Post.all,
       "is:published",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(published)
@@ -19,13 +19,13 @@ RSpec.describe "filtering by expression" do
     pig_category = create(:category, name: "pigs")
     duck_category = create(:category, name: "ducks")
     cat_post = create(:post, categories: [cat_category])
-    pig_post = create(:post, categories: [pig_category])
+    create(:post, categories: [pig_category])
     duck_post = create(:post, categories: [duck_category])
 
     result = Yuriita.filter(
       Post.all,
       "category:cats category:ducks",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(cat_post, duck_post)

--- a/spec/integration/filtering/dynamic_spec.rb
+++ b/spec/integration/filtering/dynamic_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "dynamic filtering" do
     eebs = create(:author, username: "eebs")
     sally = create(:author, username: "sally")
     eebs_post = create(:post, author: eebs)
-    sally_post = create(:post, author: sally)
+    create(:post, author: sally)
 
     result = Yuriita.filter(
       Post.all,
       "author:eebs",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(eebs_post)
@@ -19,13 +19,13 @@ RSpec.describe "dynamic filtering" do
   it "returns results matching the last input" do
     eebs = create(:author, username: "eebs")
     sally = create(:author, username: "sally")
-    eebs_post = create(:post, author: eebs)
+    create(:post, author: eebs)
     sally_post = create(:post, author: sally)
 
     result = Yuriita.filter(
       Post.all,
       "author:eebs author:sally",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(sally_post)

--- a/spec/integration/search/keyword_spec.rb
+++ b/spec/integration/search/keyword_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe "searching by keyword" do
   it "returns results including the keyword" do
     cat_post = create(:post, title: "Cats are great")
-    duck_post = create(:post, title: "Ducks are okay too")
+    create(:post, title: "Ducks are okay too")
 
     result = Yuriita.filter(
       Post.all,
       "cats",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(cat_post)
@@ -17,12 +17,12 @@ RSpec.describe "searching by keyword" do
   it "returns results with all keywords when no scope inputs are given" do
     cat_post = create(:post, title: "Cats", body: "Cats are not pigs")
     pig_post = create(:post, title: "Pigs are not cats", body: "Pigs")
-    pig_title_post = create(:post, title: "Pigs")
+    create(:post, title: "Pigs")
 
     result = Yuriita.filter(
       Post.all,
       "cats pigs",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(cat_post, pig_post)
@@ -31,13 +31,13 @@ RSpec.describe "searching by keyword" do
   it "returns results with all keywords in any of the given scope inputs" do
     cat_post = create(:post, title: "Cats", body: "Cats are not pigs")
     pig_post = create(:post, title: "Pigs are not cats", body: "Pigs")
-    pig_title_post = create(:post, title: "Pigs")
-    description_post = create(:post, description: "cats and pigs")
+    create(:post, title: "Pigs")
+    create(:post, description: "cats and pigs")
 
     result = Yuriita.filter(
       Post.all,
       "cats pigs in:title in:body",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(cat_post, pig_post)
@@ -50,7 +50,7 @@ RSpec.describe "searching by keyword" do
     result = Yuriita.filter(
       Post.all,
       "in:title",
-      PostDefinition.build,
+      PostDefinition.build
     )
 
     expect(result.relation).to contain_exactly(cat_post, pig_post)

--- a/spec/integration/sorting_spec.rb
+++ b/spec/integration/sorting_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "sorting" do
   it "sorts results" do
-    cat_post = create(:post, title: "Cats are great")
-    elephant_post = create(:post, title: "Whoa. Elephants.")
-    duck_post = create(:post, title: "Ducks are okay too")
+    create(:post, title: "Cats are great")
+    create(:post, title: "Whoa. Elephants.")
+    create(:post, title: "Ducks are okay too")
 
-    result = Yuriita.filter(
+    Yuriita.filter(
       Post.all,
       "sort:title-asc",
-      PostDefinition.build,
+      PostDefinition.build
     )
   end
 end

--- a/spec/models/genre_sync_spec.rb
+++ b/spec/models/genre_sync_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GenreSync do
       )
       client = double(:client, genres: [comedy, drama])
 
-      GenreSync.new(client: client).run
+      GenreSync.new(client:).run
 
       names = Genre.all.map(&:name)
       expect(names).to contain_exactly("Comedy", "Drama")

--- a/spec/models/genre_sync_spec.rb
+++ b/spec/models/genre_sync_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe GenreSync do
         :genre,
         name: "Comedy",
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       )
       drama = attributes_for(
         :genre,
         name: "Drama",
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       )
       client = double(:client, genres: [comedy, drama])
 

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Movie, type: :model do
   describe ".rumored" do
     it "returns movies with the rumored status" do
       rumored = create(:movie, :rumored)
-      post_production = create(:movie, :post_production)
+      create(:movie, :post_production)
 
       results = Movie.rumored
 
@@ -15,7 +15,7 @@ RSpec.describe Movie, type: :model do
   describe ".post_production" do
     it "returns movies with the rumored status" do
       post_production = create(:movie, :post_production)
-      released = create(:movie, :released)
+      create(:movie, :released)
 
       results = Movie.post_production
 
@@ -26,7 +26,7 @@ RSpec.describe Movie, type: :model do
   describe ".released" do
     it "returns movies with the rumored status" do
       released = create(:movie, :released)
-      cancelled = create(:movie, :cancelled)
+      create(:movie, :cancelled)
 
       results = Movie.released
 
@@ -37,7 +37,7 @@ RSpec.describe Movie, type: :model do
   describe ".cancelled" do
     it "returns movies with the rumored status" do
       cancelled = create(:movie, :cancelled)
-      rumored = create(:movie, :rumored)
+      create(:movie, :rumored)
 
       results = Movie.cancelled
 
@@ -48,7 +48,7 @@ RSpec.describe Movie, type: :model do
   describe ".search" do
     it "searches the given field for the term" do
       duck_movie = create(:movie, title: "Mighty Ducks")
-      not_ducks_movie = create(:movie, title: "Cats", tagline: "Cats not ducks")
+      create(:movie, title: "Cats", tagline: "Cats not ducks")
 
       results = Movie.search(:title, "ducks")
 

--- a/spec/models/movie_sync_spec.rb
+++ b/spec/models/movie_sync_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe MovieSync do
         created_at: Time.now,
         updated_at: Time.now,
       )
+
       the_prestige = attributes_for(
         :movie,
         title: "The Prestige",
         created_at: Time.now,
         updated_at: Time.now,
       )
+
       client = double(:client, top_rated: [fight_club, the_prestige], movie_genres: [])
 
-      MovieSync.new(client: client).run
+      MovieSync.new(client:).run
 
       titles = Movie.all.map(&:title)
       expect(titles).to contain_exactly("Fight Club", "The Prestige")

--- a/spec/models/movie_sync_spec.rb
+++ b/spec/models/movie_sync_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe MovieSync do
         :movie,
         title: "Fight Club",
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       )
 
       the_prestige = attributes_for(
         :movie,
         title: "The Prestige",
         created_at: Time.now,
-        updated_at: Time.now,
+        updated_at: Time.now
       )
 
       client = double(:client, top_rated: [fight_club, the_prestige], movie_genres: [])

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Post, type: :model do
   describe ".published" do
     it "returns published posts" do
       published = create(:post, :published)
-      draft = create(:post, :draft)
+      create(:post, :draft)
 
       results = Post.published
 
@@ -14,7 +14,7 @@ RSpec.describe Post, type: :model do
 
   describe ".draft" do
     it "returns draft posts" do
-      published = create(:post, :published)
+      create(:post, :published)
       draft = create(:post, :draft)
 
       results = Post.draft

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe "username" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,9 +5,9 @@ require File.expand_path("../../spec/example_app/config/environment", __FILE__)
 require "rspec/rails"
 require "capybara/rails"
 require "capybara/rspec"
-require 'pry'
+require "pry"
 
-Dir[File.expand_path('../support/**/*.rb', __FILE__)].each do |path|
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each do |path|
   require path
 end
 

--- a/spec/system/documentation_spec.rb
+++ b/spec/system/documentation_spec.rb
@@ -8,4 +8,3 @@ RSpec.describe "viewing documentation" do
     expect(page).to have_content "Installation"
   end
 end
-

--- a/spec/system/movies_spec.rb
+++ b/spec/system/movies_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "user views the movies page" do
   scenario "views a list of movies" do
-    fight_club = create(:movie, title: "Fight Club")
-    the_prestige = create(:movie, title: "The Prestige")
-    pretty_woman = create(:movie, title: "Pretty Woman")
+    create(:movie, title: "Fight Club")
+    create(:movie, title: "The Prestige")
+    create(:movie, title: "Pretty Woman")
 
     visit movies_path
 
@@ -14,9 +14,9 @@ RSpec.describe "user views the movies page" do
   end
 
   scenario "views a list of movies with a selected option" do
-    fight_club = create(:movie, :released, title: "Fight Club")
-    the_prestige = create(:movie, :rumored, title: "The Prestige")
-    pretty_woman = create(:movie, :cancelled, title: "Pretty Woman")
+    create(:movie, :released, title: "Fight Club")
+    create(:movie, :rumored, title: "The Prestige")
+    create(:movie, :cancelled, title: "Pretty Woman")
 
     visit movies_path(query: "is:released")
 
@@ -26,9 +26,9 @@ RSpec.describe "user views the movies page" do
   end
 
   scenario "clears active filters and searches" do
-    fight_club = create(:movie, :released, title: "Fight Club")
-    the_prestige = create(:movie, :rumored, title: "The Prestige")
-    pretty_woman = create(:movie, :cancelled, title: "Pretty Woman")
+    create(:movie, :released, title: "Fight Club")
+    create(:movie, :rumored, title: "The Prestige")
+    create(:movie, :cancelled, title: "Pretty Woman")
 
     visit movies_path(query: "is:released")
     click_link "Clear current search, filters, and sort"
@@ -39,8 +39,8 @@ RSpec.describe "user views the movies page" do
   end
 
   scenario "searches for a keyword", js: true do
-    fight_club = create(:movie, :released, title: "Fight Club")
-    the_prestige = create(:movie, :rumored, title: "The Prestige")
+    create(:movie, :released, title: "Fight Club")
+    create(:movie, :rumored, title: "The Prestige")
 
     visit movies_path
     fill_in "Search", with: "Fight in:title"

--- a/spec/yuriita/clauses/filter_spec.rb
+++ b/spec/yuriita/clauses/filter_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe Yuriita::Clauses::Filter do
 
       published_filter = build(
         :expression_filter,
-        block: ->(relation) { relation.published },
+        block: ->(relation) { relation.published }
       )
 
       draft_filter = build(
         :expression_filter,
-        block: ->(relation) { relation.draft },
+        block: ->(relation) { relation.draft }
       )
 
       filters = [published_filter, draft_filter]
 
       clause = described_class.new(
         filters:,
-        combination: Yuriita::OrCombination,
+        combination: Yuriita::OrCombination
       )
 
       result = clause.apply(Post.all)

--- a/spec/yuriita/clauses/filter_spec.rb
+++ b/spec/yuriita/clauses/filter_spec.rb
@@ -5,20 +5,24 @@ RSpec.describe Yuriita::Clauses::Filter do
     it "combines the applied filters using the combination" do
       published = create(:post, :published)
       draft = create(:post, :draft)
+
       published_filter = build(
         :expression_filter,
         block: ->(relation) { relation.published },
       )
+
       draft_filter = build(
         :expression_filter,
         block: ->(relation) { relation.draft },
       )
+
       filters = [published_filter, draft_filter]
 
       clause = described_class.new(
-        filters: filters,
+        filters:,
         combination: Yuriita::OrCombination,
       )
+
       result = clause.apply(Post.all)
 
       expect(result).to contain_exactly(published, draft)

--- a/spec/yuriita/clauses/search_spec.rb
+++ b/spec/yuriita/clauses/search_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Yuriita::Clauses::Search do
 
       title_filter = build(
         :search_filter,
-        block: ->(relation, term) { relation.search(:title, term) },
+        block: ->(relation, term) { relation.search(:title, term) }
       )
 
       description_filter = build(
         :search_filter,
-        block: ->(relation, term) { relation.search(:description, term) },
+        block: ->(relation, term) { relation.search(:description, term) }
       )
 
       filters = [title_filter, description_filter]
@@ -22,7 +22,7 @@ RSpec.describe Yuriita::Clauses::Search do
       clause = described_class.new(
         filters:,
         keywords: [keyword],
-        combination: Yuriita::OrCombination,
+        combination: Yuriita::OrCombination
       )
 
       result = clause.apply(Post.all)

--- a/spec/yuriita/clauses/search_spec.rb
+++ b/spec/yuriita/clauses/search_spec.rb
@@ -5,22 +5,26 @@ RSpec.describe Yuriita::Clauses::Search do
     it "combines the applied filters using the combination" do
       cats_post = create(:post, title: "cats")
       ducks_post = create(:post, title: "ducks", description: "cats")
+
       title_filter = build(
         :search_filter,
         block: ->(relation, term) { relation.search(:title, term) },
       )
+
       description_filter = build(
         :search_filter,
         block: ->(relation, term) { relation.search(:description, term) },
       )
+
       filters = [title_filter, description_filter]
       keyword = build(:keyword, value: "cats")
 
       clause = described_class.new(
-        filters: filters,
+        filters:,
         keywords: [keyword],
         combination: Yuriita::OrCombination,
       )
+
       result = clause.apply(Post.all)
 
       expect(result).to contain_exactly(cats_post, ducks_post)

--- a/spec/yuriita/collection_spec.rb
+++ b/spec/yuriita/collection_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Yuriita::Collection do
   describe ".routing" do
-
   end
 
   describe ".route" do

--- a/spec/yuriita/configuration_spec.rb
+++ b/spec/yuriita/configuration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Yuriita::Configuration do
       published = double(:definition)
       sort = double(:definition)
 
-      config = described_class.new({ published: published, sort: sort })
+      config = described_class.new({published: published, sort: sort})
 
       expect do |b|
         config.each(&b)
@@ -16,7 +16,7 @@ RSpec.describe Yuriita::Configuration do
     it "returns a definition by key" do
       definition = double(:definition)
 
-      config = described_class.new({ foo: definition })
+      config = described_class.new({foo: definition})
 
       expect(config.find_definition(:foo)).to eq definition
     end
@@ -26,7 +26,7 @@ RSpec.describe Yuriita::Configuration do
 
       expect { config.find_definition(:foo) }.to raise_exception(
         KeyError,
-        "key not found: :foo",
+        "key not found: :foo"
       )
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe Yuriita::Configuration do
     it "returns the number of definitions" do
       definitions = {
         published: double(:definition),
-        sort: double(:definition),
+        sort: double(:definition)
       }
       config = described_class.new(definitions)
 
@@ -47,7 +47,7 @@ RSpec.describe Yuriita::Configuration do
     it "returns the default input" do
       definitions = {
         published: double(:definition),
-        sort: double(:definition),
+        sort: double(:definition)
       }
       config = described_class.new(definitions, default_input: "is:published")
       expect(config.default_input).to eq "is:published"

--- a/spec/yuriita/lexer_spec.rb
+++ b/spec/yuriita/lexer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Yuriita::Lexer do
           "WORD(is)",
           "COLON",
           "WORD(active)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -17,7 +17,7 @@ RSpec.describe Yuriita::Lexer do
           "WORD(first)",
           "SPACE",
           "WORD(last)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -28,7 +28,7 @@ RSpec.describe Yuriita::Lexer do
           "WORD(created_by)",
           "COLON",
           "WORD(eebs)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -39,7 +39,7 @@ RSpec.describe Yuriita::Lexer do
           "WORD(sort)",
           "COLON",
           "WORD(created-desc)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -50,7 +50,7 @@ RSpec.describe Yuriita::Lexer do
           "WORD(email)",
           "COLON",
           "WORD(user.name123@example.com)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -63,7 +63,7 @@ RSpec.describe Yuriita::Lexer do
           "SPACE",
           "WORD(words)",
           "QUOTE",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -76,7 +76,7 @@ RSpec.describe Yuriita::Lexer do
           "COLON",
           "GT",
           "DATETIME(2020-01-01T00:00:00+00:00)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -89,7 +89,7 @@ RSpec.describe Yuriita::Lexer do
           "COLON",
           "GT",
           "DATETIME(2020-01-01T15:30:00+03:00)",
-          "EOS",
+          "EOS"
         ]
       )
     end
@@ -102,7 +102,7 @@ RSpec.describe Yuriita::Lexer do
           "COLON",
           "GT",
           "DATETIME(2020-01-01T15:30:00+00:00)",
-          "EOS",
+          "EOS"
         ]
       )
     end

--- a/spec/yuriita/option_spec.rb
+++ b/spec/yuriita/option_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Yuriita::Option do
   it "equality is based on the option's name" do
     filter = double(:filter)
-    option_a = described_class.new(name: "One", filter: filter)
-    option_b = described_class.new(name: "One", filter: filter)
-    option_c = described_class.new(name: "Two", filter: filter)
+    option_a = described_class.new(name: "One", filter:)
+    option_b = described_class.new(name: "One", filter:)
+    option_c = described_class.new(name: "Two", filter:)
 
     expect(option_a).to eq(option_a)
     expect(option_a).to eq(option_b)

--- a/spec/yuriita/parser_spec.rb
+++ b/spec/yuriita/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Yuriita::Parser do
-  describe '#parse' do
+  describe "#parse" do
     it "parses an empty string" do
       query = parse(tokens([:EOS]))
 
@@ -17,12 +17,12 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "hello"],
         [:SPACE],
         [:WORD, "label"], [:COLON], [:WORD, "bug"],
-        [:EOS],
+        [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
         expression("label", "bug"),
-        keyword("hello"),
+        keyword("hello")
       )
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Yuriita::Parser do
         [:QUOTE],
         [:WORD, "hello"], [:SPACE], [:WORD, "world"],
         [:QUOTE],
-        [:EOS],
+        [:EOS]
       ))
 
       expect(query.inputs).to eq [keyword("hello world")]
@@ -44,13 +44,13 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "label"], [:COLON], [:WORD, "bug"],
         [:SPACE],
         [:WORD, "world"],
-        [:EOS],
+        [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
         expression("label", "bug"),
         keyword("hello"),
-        keyword("world"),
+        keyword("world")
       )
     end
 
@@ -63,14 +63,14 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "world"],
         [:SPACE],
         [:WORD, "label"], [:COLON], [:WORD, "security"],
-        [:EOS],
+        [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
         expression("label", "bug"),
         expression("label", "security"),
         keyword("hello"),
-        keyword("world"),
+        keyword("world")
       )
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "label"], [:COLON], [:WORD, "green"],
         [:SPACE],
         [:WORD, "term"],
-        [:EOS],
+        [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
@@ -99,7 +99,7 @@ RSpec.describe Yuriita::Parser do
         keyword("hello"),
         keyword("world"),
         keyword("search"),
-        keyword("term"),
+        keyword("term")
       )
     end
 
@@ -107,28 +107,28 @@ RSpec.describe Yuriita::Parser do
       query = parse(tokens([:WORD, "is"], [:COLON], [:WORD, "active"], [:EOS]))
 
       expect(query.inputs).to contain_exactly(
-        expression("is", "active"),
+        expression("is", "active")
       )
     end
 
     it "parses an expression input with a quoted word" do
       query = parse(tokens(
-        [:WORD, "label"], [:COLON], [:QUOTE], [:WORD, "bug"], [:QUOTE], [:EOS],
+        [:WORD, "label"], [:COLON], [:QUOTE], [:WORD, "bug"], [:QUOTE], [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
-        expression("label", "bug"),
+        expression("label", "bug")
       )
     end
 
     it "parses an expression input with a quoted phrase" do
       query = parse(tokens(
         [:WORD, "label"], [:COLON], [:QUOTE], [:WORD, "bug"], [:SPACE],
-        [:WORD, "report"], [:QUOTE], [:EOS],
+        [:WORD, "report"], [:QUOTE], [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
-        expression("label", "bug report"),
+        expression("label", "bug report")
       )
     end
 
@@ -137,11 +137,11 @@ RSpec.describe Yuriita::Parser do
         [:WORD, "label"], [:COLON],
         [:QUOTE],
         [:SPACE], [:WORD, "bug"], [:SPACE], [:WORD, "report"], [:SPACE],
-        [:QUOTE], [:EOS],
+        [:QUOTE], [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
-        expression("label", "bug report"),
+        expression("label", "bug report")
       )
     end
 
@@ -149,13 +149,13 @@ RSpec.describe Yuriita::Parser do
       query = parse(tokens(
         [:WORD, "label"], [:COLON], [:WORD, "bug"], [:SPACE],
         [:WORD, "label"], [:COLON], [:WORD, "security"], [:SPACE],
-        [:WORD, "author"], [:COLON], [:WORD, "eebs"], [:EOS],
+        [:WORD, "author"], [:COLON], [:WORD, "eebs"], [:EOS]
       ))
 
       expect(query.inputs).to contain_exactly(
         expression("label", "bug"),
         expression("label", "security"),
-        expression("author", "eebs"),
+        expression("author", "eebs")
       )
     end
   end

--- a/spec/yuriita/router_spec.rb
+++ b/spec/yuriita/router_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Yuriita::Router do
       router.append_route(
         collection,
         ->(input) { input.term == "published" },
-        to: :published,
+        to: :published
       )
       input = expression("is", "published")
 

--- a/spec/yuriita/selects/all_or_explicit_spec.rb
+++ b/spec/yuriita/selects/all_or_explicit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
 
         selector = described_class.new(
           options: [title_option, tagline_option],
-          query:,
+          query:
         )
 
         expect(selector.filters).to eq [title_filter, tagline_filter]
@@ -36,13 +36,13 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
           :query,
           inputs: [
             build(:expression, qualifier: "in", term: "title"),
-            build(:expression, qualifier: "in", term: "note"),
-          ],
+            build(:expression, qualifier: "in", term: "note")
+          ]
         )
 
         selector = described_class.new(
           options: [title_option, tagline_option, note_option],
-          query:,
+          query:
         )
 
         expect(selector.filters).to eq [title_filter, note_filter]

--- a/spec/yuriita/selects/all_or_explicit_spec.rb
+++ b/spec/yuriita/selects/all_or_explicit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
 
         selector = described_class.new(
           options: [title_option, tagline_option],
-          query: query,
+          query:,
         )
 
         expect(selector.filters).to eq [title_filter, tagline_filter]
@@ -42,7 +42,7 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
 
         selector = described_class.new(
           options: [title_option, tagline_option, note_option],
-          query: query,
+          query:,
         )
 
         expect(selector.filters).to eq [title_filter, note_filter]
@@ -51,7 +51,7 @@ RSpec.describe Yuriita::Selects::AllOrExplicit do
   end
 
   def build_option(name, qualifier, term)
-    input = build(:expression, qualifier: qualifier, term: term)
-    build(:option, name: name, filter: build(:search_filter, input: input))
+    input = build(:expression, qualifier:, term:)
+    build(:option, name:, filter: build(:search_filter, input:))
   end
 end

--- a/spec/yuriita/selects/exclusive_spec.rb
+++ b/spec/yuriita/selects/exclusive_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query:,
+          query:
         )
 
         expect(selector.filter).to eq active_filter
@@ -32,13 +32,13 @@ RSpec.describe Yuriita::Selects::Exclusive do
 
         query = build(
           :query,
-          inputs: [build(:expression, qualifier: "is", term: "active")],
+          inputs: [build(:expression, qualifier: "is", term: "active")]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query:,
+          query:
         )
 
         expect(selector.filter).to eq active_filter
@@ -57,7 +57,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query:,
+          query:
         )
 
         result = selector.selected?(active_option)
@@ -74,7 +74,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query:,
+          query:
         )
 
         result = selector.selected?(hidden_option)
@@ -90,13 +90,13 @@ RSpec.describe Yuriita::Selects::Exclusive do
 
         query = build(
           :query,
-          inputs: [build(:expression, qualifier: "is", term: "active")],
+          inputs: [build(:expression, qualifier: "is", term: "active")]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query:,
+          query:
         )
 
         result = selector.selected?(active_option)
@@ -114,14 +114,14 @@ RSpec.describe Yuriita::Selects::Exclusive do
           :query,
           inputs: [
             build(:expression, qualifier: "is", term: "hidden"),
-            build(:expression, qualifier: "is", term: "active"),
-          ],
+            build(:expression, qualifier: "is", term: "active")
+          ]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query:,
+          query:
         )
 
         active_selected = selector.selected?(active_option)

--- a/spec/yuriita/selects/exclusive_spec.rb
+++ b/spec/yuriita/selects/exclusive_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query: query,
+          query:,
         )
 
         expect(selector.filter).to eq active_filter
@@ -38,7 +38,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query: query,
+          query:,
         )
 
         expect(selector.filter).to eq active_filter
@@ -57,8 +57,9 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query: query,
+          query:,
         )
+
         result = selector.selected?(active_option)
 
         expect(result).to be true
@@ -73,8 +74,9 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: active_option,
-          query: query,
+          query:,
         )
+
         result = selector.selected?(hidden_option)
 
         expect(result).to be false
@@ -94,8 +96,9 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query: query,
+          query:,
         )
+
         result = selector.selected?(active_option)
 
         expect(result).to be true
@@ -118,8 +121,9 @@ RSpec.describe Yuriita::Selects::Exclusive do
         selector = described_class.new(
           options: [active_option, hidden_option],
           default: hidden_option,
-          query: query,
+          query:,
         )
+
         active_selected = selector.selected?(active_option)
         hidden_selected = selector.selected?(hidden_option)
 
@@ -130,7 +134,7 @@ RSpec.describe Yuriita::Selects::Exclusive do
   end
 
   def build_option(name, qualifier, term)
-    input = build(:expression, qualifier: qualifier, term: term)
-    build(:option, name: name, filter: build(:expression_filter, input: input))
+    input = build(:expression, qualifier:, term:)
+    build(:option, name:, filter: build(:expression_filter, input:))
   end
 end

--- a/spec/yuriita/selects/multiple_spec.rb
+++ b/spec/yuriita/selects/multiple_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       query = build(
         :query,
-        inputs: [build(:expression, qualifier: "is", term: "active")],
+        inputs: [build(:expression, qualifier: "is", term: "active")]
       )
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query:,
+        query:
       )
 
       expect(selector.filters).to eq [active_filter]
@@ -29,12 +29,12 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       query = build(
         :query,
-        inputs: [build(:expression, qualifier: "is", term: "active")],
+        inputs: [build(:expression, qualifier: "is", term: "active")]
       )
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query:,
+        query:
       )
 
       result = selector.selected?(active_option)
@@ -48,12 +48,12 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       query = build(
         :query,
-        inputs: [build(:expression, qualifier: "is", term: "active")],
+        inputs: [build(:expression, qualifier: "is", term: "active")]
       )
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query:,
+        query:
       )
 
       result = selector.selected?(hidden_option)
@@ -67,7 +67,7 @@ RSpec.describe Yuriita::Selects::Multiple do
     build(
       :option,
       name:,
-      filter: build(:expression_filter, input: expression),
+      filter: build(:expression_filter, input: expression)
     )
   end
 end

--- a/spec/yuriita/selects/multiple_spec.rb
+++ b/spec/yuriita/selects/multiple_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query: query,
+        query:,
       )
 
       expect(selector.filters).to eq [active_filter]
@@ -26,6 +26,7 @@ RSpec.describe Yuriita::Selects::Multiple do
     it "returns true if the given option's input is in the query" do
       active_option = build_option("Active", "is", "active")
       hidden_option = build_option("Hidden", "is", "hidden")
+
       query = build(
         :query,
         inputs: [build(:expression, qualifier: "is", term: "active")],
@@ -33,8 +34,9 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query: query,
+        query:,
       )
+
       result = selector.selected?(active_option)
 
       expect(result).to be true
@@ -43,6 +45,7 @@ RSpec.describe Yuriita::Selects::Multiple do
     it "returns false if the given option's input is not in the query" do
       active_option = build_option("Active", "is", "active")
       hidden_option = build_option("Hidden", "is", "hidden")
+
       query = build(
         :query,
         inputs: [build(:expression, qualifier: "is", term: "active")],
@@ -50,8 +53,9 @@ RSpec.describe Yuriita::Selects::Multiple do
 
       selector = described_class.new(
         options: [active_option, hidden_option],
-        query: query,
+        query:,
       )
+
       result = selector.selected?(hidden_option)
 
       expect(result).to be false
@@ -59,10 +63,10 @@ RSpec.describe Yuriita::Selects::Multiple do
   end
 
   def build_option(name, qualifier, term)
-    expression = build(:expression, qualifier: qualifier, term: term)
+    expression = build(:expression, qualifier:, term:)
     build(
       :option,
-      name: name,
+      name:,
       filter: build(:expression_filter, input: expression),
     )
   end

--- a/spec/yuriita/selects/single_spec.rb
+++ b/spec/yuriita/selects/single_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Yuriita::Selects::Single do
 
         query = build(
           :query,
-          inputs: [build(:expression, qualifier: "author", term: "eebs")],
+          inputs: [build(:expression, qualifier: "author", term: "eebs")]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query:,
+          query:
         )
 
         expect(selector.filter).to be nil
@@ -34,12 +34,12 @@ RSpec.describe Yuriita::Selects::Single do
 
         query = build(
           :query,
-          inputs: [build(:expression, qualifier: "is", term: "active")],
+          inputs: [build(:expression, qualifier: "is", term: "active")]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query:,
+          query:
         )
 
         expect(selector.filter).to eq active_filter
@@ -57,7 +57,7 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query:,
+          query:
         )
 
         result = selector.selected?(active_option)
@@ -73,12 +73,12 @@ RSpec.describe Yuriita::Selects::Single do
 
         query = build(
           :query,
-          inputs: [build(:expression, qualifier: "is", term: "active")],
+          inputs: [build(:expression, qualifier: "is", term: "active")]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query:,
+          query:
         )
 
         result = selector.selected?(active_option)
@@ -96,13 +96,13 @@ RSpec.describe Yuriita::Selects::Single do
           :query,
           inputs: [
             build(:expression, qualifier: "is", term: "hidden"),
-            build(:expression, qualifier: "is", term: "active"),
-          ],
+            build(:expression, qualifier: "is", term: "active")
+          ]
         )
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query:,
+          query:
         )
 
         active_selected = selector.selected?(active_option)

--- a/spec/yuriita/selects/single_spec.rb
+++ b/spec/yuriita/selects/single_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query: query,
+          query:,
         )
 
         expect(selector.filter).to be nil
@@ -39,7 +39,7 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query: query,
+          query:,
         )
 
         expect(selector.filter).to eq active_filter
@@ -57,8 +57,9 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query: query,
+          query:,
         )
+
         result = selector.selected?(active_option)
 
         expect(result).to be false
@@ -77,8 +78,9 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query: query,
+          query:,
         )
+
         result = selector.selected?(active_option)
 
         expect(result).to be true
@@ -100,8 +102,9 @@ RSpec.describe Yuriita::Selects::Single do
 
         selector = described_class.new(
           options: [active_option, hidden_option],
-          query: query,
+          query:,
         )
+
         active_selected = selector.selected?(active_option)
         hidden_selected = selector.selected?(hidden_option)
 
@@ -112,7 +115,7 @@ RSpec.describe Yuriita::Selects::Single do
   end
 
   def build_option(name, qualifier, term)
-    input = build(:expression, qualifier: qualifier, term: term)
-    build(:option, name: name, filter: build(:expression_filter, input: input))
+    input = build(:expression, qualifier:, term:)
+    build(:option, name:, filter: build(:expression_filter, input:))
   end
 end

--- a/spec/yuriita/table_spec.rb
+++ b/spec/yuriita/table_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:published"),
-        params: {},
+        params: {}
       )
 
       expect(table.q).to eq "is:published "
@@ -14,7 +14,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:published"),
-        params: { q: "" },
+        params: {q: ""}
       )
 
       expect(table.q).to eq ""
@@ -27,7 +27,7 @@ RSpec.describe Yuriita::Table do
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:published"),
         param_key: :query,
-        params: {query: "is:published"},
+        params: {query: "is:published"}
       )
 
       expect(table.search.query).to eq "is:published "
@@ -39,7 +39,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:published"),
-        params: { q: "is:draft" },
+        params: {q: "is:draft"}
       )
 
       expect(table.filtered?).to be true
@@ -49,7 +49,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "author:eebs is:draft"),
-        params: { q: "is:draft author:eebs" },
+        params: {q: "is:draft author:eebs"}
       )
 
       expect(table.filtered?).to be true
@@ -59,7 +59,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:published"),
-        params: { q: "is:published" },
+        params: {q: "is:published"}
       )
 
       expect(table.filtered?).to be false
@@ -69,7 +69,7 @@ RSpec.describe Yuriita::Table do
       table = described_class.new(
         relation: double(:relation),
         configuration: double(:configuration, default_input: "is:released"),
-        params: {},
+        params: {}
       )
 
       expect(table.filtered?).to be false

--- a/yuri-ita.gemspec
+++ b/yuri-ita.gemspec
@@ -3,23 +3,23 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "yuriita/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "yuri-ita"
-  spec.version       = Yuriita::VERSION
-  spec.authors       = ["Louis Antonopoulos", "Sally Hall", "Eebs Kobeissi"]
-  spec.email         = ["louis@thoughtbot.com"]
+  spec.name = "yuri-ita"
+  spec.version = Yuriita::VERSION
+  spec.authors = ["Louis Antonopoulos", "Sally Hall", "Eebs Kobeissi"]
+  spec.email = ["louis@thoughtbot.com"]
 
-  spec.summary       = %q{Filter and search using an expressive, user defined, query language}
-  spec.homepage      = "https://github.com/thoughtbot/yuri-ita"
+  spec.summary = "Filter and search using an expressive, user defined, query language"
+  spec.homepage = "https://github.com/thoughtbot/yuri-ita"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/thoughtbot/yuri-ita/blob/main/NEWS.md"
 
   # Specify which files should be added to the gem when it is released.
-  spec.files         = Dir["{lib}/**/*", "LICENSE"]
-  spec.license       = "LicenseRef-LICENSE"
+  spec.files = Dir["{lib}/**/*", "LICENSE"]
+  spec.license = "LicenseRef-LICENSE"
 
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = "~> 3.1"
 


### PR DESCRIPTION
**This PR:**
- Implements Ruby shorthand for method calls (e.g., `new(method:) instead of new(method: method)`
- Applies linting via [Standard Ruby](https://github.com/standardrb/standard)